### PR TITLE
Dockerize gpumon: container deployment, host metrics, Lambda fleet manager

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+*.md
+.env
+autoinstall.sh
+__pycache__
+*.pyc

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# ── Slack Bot (primary notification channel) ──────────────────────────────────
+# Secret Manager secret that stores the Slack Bot OAuth token (xoxb-...).
+# The bot needs scopes: users:read, users:read.email, im:write, chat:write
+# GPUMON_SLACK_SECRET_ID=AB/SlackBotToken
+# GPUMON_SLACK_SECRET_REGION=eu-west-1
+
+# ── Slack webhooks (fallback when bot token is unavailable) ───────────────────
+# DEBUG_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+# ML_TEAM_TEAM_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+
+# ── Alert thresholds ──────────────────────────────────────────────────────────
+# DISK_ALERT_FREE_PCT=10          # DM employee when root disk free < this %
+# MEMORY_ALERT_USED_PCT=90        # DM employee when RAM used > this %
+# ALERT_COOLDOWN_HOURS=12         # min hours between repeat disk/memory DMs
+# SHUTDOWN_ALERT_COOLDOWN_HOURS=4 # min hours between repeat idle-shutdown DMs
+
+# ── Secrets Manager (instance stop credentials) ───────────────────────────────
+# GPUMON_SECRET_ID=AB/InstanceRole
+# GPUMON_SECRET_REGION=eu-west-1

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # ── Slack Bot (employee DMs) ──────────────────────────────────────────────────
 # Secret Manager secret that stores the Slack Bot OAuth token (xoxb-...).
 # The bot needs scopes: users:read, users:read.email, im:write, chat:write
-# GPUMON_SLACK_SECRET_ID=AB/SlackBotToken
+# GPUMON_SLACK_SECRET_ID=IT/SLACK_BOT_TOKEN
 # GPUMON_SLACK_SECRET_REGION=eu-west-1
 
 # ── Alert thresholds ──────────────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,8 @@
-# ── Slack Bot (primary notification channel) ──────────────────────────────────
+# ── Slack Bot (employee DMs) ──────────────────────────────────────────────────
 # Secret Manager secret that stores the Slack Bot OAuth token (xoxb-...).
 # The bot needs scopes: users:read, users:read.email, im:write, chat:write
 # GPUMON_SLACK_SECRET_ID=AB/SlackBotToken
 # GPUMON_SLACK_SECRET_REGION=eu-west-1
-
-# ── Slack webhooks (fallback when bot token is unavailable) ───────────────────
-# DEBUG_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
-# ML_TEAM_TEAM_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 
 # ── Alert thresholds ──────────────────────────────────────────────────────────
 # DISK_ALERT_FREE_PCT=10          # DM employee when root disk free < this %

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 */.DS_Store
+.env
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,6 @@ COPY gpumon.py cpumon.py hostmon.py mon_utils.py slack_dm.py docker-entrypoint.s
 RUN chmod +x docker-entrypoint.sh
 
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
-    CMD pgrep -f "gpumon.py\|cpumon.py" > /dev/null || exit 1
+    CMD pgrep -f "gpumon.py" > /dev/null || pgrep -f "cpumon.py" > /dev/null || exit 1
 
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM nvidia/cuda:12.2.0-base-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+        python3 \
+        python3-pip \
+        curl \
+        awscli \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY gpumon.py cpumon.py hostmon.py mon_utils.py slack_dm.py docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
+HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
+    CMD pgrep -f "gpumon.py\|cpumon.py" > /dev/null || exit 1
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.2.0-base-ubuntu22.04
+FROM public.ecr.aws/nvidia/cuda:12.2.0-base-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/nvidia/cuda:12.2.0-base-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:12.2.0-base-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Controls idle-detection sensitivity in `halt_it.sh` and the Python monitors.
 | `RELAXED` | 2 h | 5 % | 10 % | 10 000 pkts |
 | `SEVERE` | 0 | 20 % | 2 % | 15 000 pkts |
 | `SPOT` | 0 | 20 % | 10 % | 30 000 pkts |
-| `SUSPEND` | 24 h | 10 % | 10 % | 15 000 pkts |
+| `SUSPEND` | 10 days | 10 % | 10 % | 15 000 pkts |
 
 `SPOT` additionally suppresses all employee Slack DMs regardless of the `PAGE_EMPLOYEE` tag.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ sudo bash /root/gpumon/autoinstall.sh
 | Tag | Required | Values / Default | Purpose |
 |-----|----------|-----------------|---------|
 | `GPUMON` | **Yes** | see state machine below | Drives Lambda fleet actions |
-| `GPUMON_BRANCH` | No | `main` / `feature/dockerize` | Branch to clone during install or migrate |
+| `GPUMON_BRANCH` | No | default: `feature/dockerize` | Branch to clone during install or migrate; update `DOCKER_BRANCH` constant after merge |
 | `GPUMON_POLICY` | No | `STANDARD` *(default)* | Idle-shutdown sensitivity |
 | `Team` | No | e.g. `ML_TEAM` | Determines Slack team webhook; CloudWatch dimension |
 | `Employee` | No | Name or `user@email.com` | Slack DM recipient for personal alerts |
@@ -106,7 +106,7 @@ sudo bash /root/gpumon/autoinstall.sh
 
 | Tag value | Lambda action |
 |-----------|--------------|
-| `install` | Clone `GPUMON_BRANCH` (default `main`), run `autoinstall.sh` |
+| `install` | Clone `GPUMON_BRANCH` (default `feature/dockerize`), run `autoinstall.sh` |
 | `PENDING_SSM` | Retry install (SSM agent was absent on first attempt) |
 | `ACTIVE` | Health-check; set `FAILED` if not running |
 | `INACTIVE` | Health-check when instance comes back up |
@@ -269,8 +269,8 @@ Set `GPUMON_BRANCH` on an instance to override which git branch is cloned. Defau
 
 | Action | Default branch |
 |--------|---------------|
-| `install` | `main` |
-| `MIGRATE` | `feature/dockerize` (update `DOCKER_BRANCH` constant when merged) |
+| `install` | `feature/dockerize` (update `DOCKER_BRANCH` constant after merge) |
+| `MIGRATE` | `feature/dockerize` (update `DOCKER_BRANCH` constant after merge) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Copy `.env.example` to `.env` in the repo directory before starting the containe
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GPUMON_SLACK_SECRET_ID` | `AB/SlackBotToken` | Secrets Manager secret for the Slack Bot token |
+| `GPUMON_SLACK_SECRET_ID` | `IT/SLACK_BOT_TOKEN` | Secrets Manager secret for the Slack Bot token |
 | `GPUMON_SLACK_SECRET_REGION` | `eu-west-1` | Region where the Slack secret lives |
 | `GPUMON_SECRET_ID` | `AB/InstanceRole` | Secrets Manager secret for stop/terminate credentials |
 | `GPUMON_SECRET_REGION` | `eu-west-1` | Region where the stop-credential secret lives |
@@ -310,7 +310,7 @@ The `/tmp:/tmp` bind-mount means alert state (`gpumon_alert_state.json`) and log
 | `docker-entrypoint.sh` | Detects GPU, launches gpumon.py or cpumon.py + hostmon.py |
 | `Dockerfile` | `nvidia/cuda:12.2.0-base-ubuntu22.04` base, Python 3, boto3, pynvml |
 | `docker-compose.yml` | GPU variant: `network_mode: host`, `pid: host`, `/tmp:/tmp`, all GPUs |
-| `docker-compose.cpu.yml` | CPU override: removes NVIDIA device reservation |
+| `docker-compose.cpu.yml` | CPU standalone compose: no GPU config, forces `runtime: runc` |
 | `lambda_manager.py` | AWS Lambda fleet manager (SSM, EC2 tags, IAM) |
 | `requirements.txt` | Pinned Python dependencies |
 | `.env.example` | Template for all configurable environment variables |
@@ -326,7 +326,7 @@ The `/tmp:/tmp` bind-mount means alert state (`gpumon_alert_state.json`) and log
 docker compose up -d
 
 # CPU-only instance
-docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
+docker compose -f docker-compose.cpu.yml up -d
 
 # Rebuild after code change
 docker compose up -d --build

--- a/README.md
+++ b/README.md
@@ -1,54 +1,354 @@
- Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# gpumon — AWS EC2 GPU/CPU Fleet Monitor
 
- Licensed under the Apache License, Version 2.0 (the "License").
- You may not use this file except in compliance with the License.
- A copy of the License is located at
+Containerised CloudWatch metrics, idle-shutdown automation, and Slack alerting for GPU and CPU EC2 instances. Deployed and managed entirely through EC2 tags — no SSH required.
 
-     http://www.apache.org/licenses/LICENSE-2.0
-  
-  or in the "license" file accompanying this file. This file is distributed 
-  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-  express or implied. See the License for the specific language governing 
-  permissions and limitations under the License.
+---
 
-Some changes to script have been made by Paul Seifer to adapt to python3.9, such as conversion of values to utf-8 strings.
+## Overview
 
-To install the script on an EC2 instance that has GPUs, please follow the steps:
+gpumon runs as a Docker container on each monitored EC2 instance. It continuously publishes custom CloudWatch metrics, watches for idle conditions, and pages the responsible employee via Slack DM when intervention is needed. The host-side `halt_it.sh` script, driven by those metrics, stops or terminates the instance after a sustained idle period.
+
+A Lambda function acts as a fleet manager: it reads the `GPUMON` tag on every EC2 instance and installs, health-checks, fixes, migrates, or removes gpumon entirely — all without operator SSH access.
+
 ```
-apt update -y && apt install curl -y && apt install python3-pip -y && pip install boto3 && pip install pynvml && pip install psutil
-git clone https://github.com/autobrains/gpumon.git
-rm -f /etc/systemd/system/gpumon.service
-touch /etc/systemd/system/gpumon.service
-chmod 664 /etc/systemd/system/gpumon.service
+┌───────────────────────────────────────────────────────────────────────┐
+│  EC2 Instance                                                         │
+│                                                                       │
+│  ┌─────────────────────────────────────────────────┐                  │
+│  │  Docker Container (gpumon)                      │                  │
+│  │                                                 │                  │
+│  │  docker-entrypoint.sh                           │                  │
+│  │    ├── gpumon.py  (GPU instances)  ─────────────┼──► CloudWatch   │
+│  │    │   or cpumon.py (CPU only)    ─────────────┼──► GPU/CPU-metrics│
+│  │    └── hostmon.py (always)        ─────────────┼──► Host-metrics  │
+│  │                                                 │                  │
+│  │  /tmp:/tmp  bind-mount ◄────────────────────────┼─ shared logs     │
+│  └─────────────────────────────────────────────────┘                  │
+│                                                                       │
+│  Host crontab (every 10 min)                                          │
+│    └── halt_it.sh  ──► reads /tmp/GPU_TEMP_* or CPUMON_LOGS_*        │
+│                    ──► if idle 2 h: stop/terminate instance           │
+│                                                                       │
+│  Systemd timer (5 min post-boot, then hourly)                         │
+│    └── gpumon-update.sh  ──► git pull + docker compose up -d --build  │
+└───────────────────────────────────────────────────────────────────────┘
 
-tee -a /etc/systemd/system/gpumon.service > /dev/null <<EOT
-#gpumon-service
-[Unit]
-Description=gpumon_proccess
-After=network.target
-Wants=network.target
-
-[Install]
-WantedBy=multi-user.target
-
-[Service]
-User=root
-Group=root
-Type=simple
-Restart=on-failure
-ExecStartPre=git -C /root/gpumon pull
-ExecStart=python3 /root/gpumon/gpumon.py
-EOT
-
-
-systemctl daemon-reload
-systemctl start gpumon
-systemctl enable gpumon
-systemctl status gpumon
+       Lambda (scheduled, all regions)
+         └── reads GPUMON tag ──► install / check / fix / migrate / delete
 ```
 
-To update the instance with a new version of code after merge to master use `update_remote.sh`
+---
 
-Syntax: 
+## Quick Start — single instance
 
-`update_remote.sh <ip_of_the_ec2_instance> <path_to_ssh_key>`
+```bash
+# 1. Clone the repo (Lambda does this automatically for managed fleets)
+git clone https://github.com/autobrains/gpumon.git /root/gpumon
+
+# 2. (Optional) configure Slack and alert thresholds
+cp /root/gpumon/.env.example /root/gpumon/.env
+$EDITOR /root/gpumon/.env
+
+# 3. Run the idempotent installer
+sudo bash /root/gpumon/autoinstall.sh
+```
+
+`autoinstall.sh` installs Docker, the NVIDIA Container Toolkit (GPU instances only), builds the image, starts the container, installs `halt_it.sh` to the host crontab, and registers a systemd timer for hourly auto-updates. Re-running it is safe — remove `/var/log/gpumon.finished` to force a full reinstall.
+
+---
+
+## EC2 Tags Reference
+
+| Tag | Required | Values / Default | Purpose |
+|-----|----------|-----------------|---------|
+| `GPUMON` | **Yes** | see state machine below | Drives Lambda fleet actions |
+| `GPUMON_BRANCH` | No | `main` / `feature/dockerize` | Branch to clone during install or migrate |
+| `GPUMON_POLICY` | No | `STANDARD` *(default)* | Idle-shutdown sensitivity |
+| `Team` | No | e.g. `ML_TEAM` | Determines Slack team webhook; CloudWatch dimension |
+| `Employee` | No | Name or `user@email.com` | Slack DM recipient for personal alerts |
+| `PAGE_EMPLOYEE` | No | `True` *(default)* / `False` | Set to `False` to suppress employee DMs |
+| `Name` | No | human-readable name | Used in Slack alert messages instead of instance ID |
+
+### GPUMON tag state machine
+
+```
+                  ┌─────────┐
+  (set manually)  │ install │──────────────────────────────────┐
+                  └─────────┘                                  │
+                                                               ▼
+  (set manually)  ┌─────────┐     install OK?     ┌────────────────┐
+                  │PENDING_ │──── Docker running ─►│    ACTIVE      │◄──┐
+                  │   SSM   │                      └────────────────┘   │
+                  └─────────┘                             │ check fails  │
+                                                          ▼             │
+                  ┌─────────┐     fix succeeds     ┌────────────────┐  │
+                  │ FAILED  │◄────────────────────  │    FAILED      │  │
+                  └─────────┘     step 1 or 2 OK──►│                │  │
+                       │                            └────────────────┘  │
+                       │ no Docker (legacy)                 │ fix OK     │
+                       ▼                                    └───────────┘
+                  ┌─────────┐
+                  │NOT_FIXED│  (manual attention required)
+                  └─────────┘
+
+  (set manually)  ┌─────────┐     migration OK    ┌────────────────┐
+                  │ MIGRATE │────────────────────►│    ACTIVE      │
+                  └─────────┘                      └────────────────┘
+
+  (set manually)  ┌─────────┐     always clears
+                  │ DELETE  │────────────────────► tag = ""
+                  └─────────┘
+
+  instance not running ──► INACTIVE (any non-empty tag)
+```
+
+**Lambda sweep actions by tag value:**
+
+| Tag value | Lambda action |
+|-----------|--------------|
+| `install` | Clone `GPUMON_BRANCH` (default `main`), run `autoinstall.sh` |
+| `PENDING_SSM` | Retry install (SSM agent was absent on first attempt) |
+| `ACTIVE` | Health-check; set `FAILED` if not running |
+| `INACTIVE` | Health-check when instance comes back up |
+| `FAILED` | Progressive fix: step 1 = `git pull` + rebuild; step 2 = full reinstall |
+| `NOT_FIXED` | Skipped — requires manual investigation |
+| `MIGRATE` | Stop legacy processes/units, clone Docker branch, run `autoinstall.sh` |
+| `DELETE` | `docker compose down`, remove timer, crontab entry, and repo |
+| *(empty)* | Ignored |
+
+---
+
+## GPUMON_POLICY Tag
+
+Controls idle-detection sensitivity in `halt_it.sh` and the Python monitors.
+
+| Policy | Restart backoff | CPU threshold | GPU threshold | Network threshold |
+|--------|----------------|--------------|--------------|------------------|
+| `STANDARD` | 1 h | 10 % | 10 % | 15 000 pkts |
+| `RELAXED` | 2 h | 5 % | 10 % | 10 000 pkts |
+| `SEVERE` | 0 | 20 % | 2 % | 15 000 pkts |
+| `SPOT` | 0 | 20 % | 10 % | 30 000 pkts |
+| `SUSPEND` | 24 h | 10 % | 10 % | 15 000 pkts |
+
+`SPOT` additionally suppresses all employee Slack DMs regardless of the `PAGE_EMPLOYEE` tag.
+
+---
+
+## Environment Variables (`.env`)
+
+Copy `.env.example` to `.env` in the repo directory before starting the container.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GPUMON_SLACK_SECRET_ID` | `AB/SlackBotToken` | Secrets Manager secret for the Slack Bot token |
+| `GPUMON_SLACK_SECRET_REGION` | `eu-west-1` | Region where the Slack secret lives |
+| `GPUMON_SECRET_ID` | `AB/InstanceRole` | Secrets Manager secret for stop/terminate credentials |
+| `GPUMON_SECRET_REGION` | `eu-west-1` | Region where the stop-credential secret lives |
+| `DISK_ALERT_FREE_PCT` | `10` | DM employee when root disk free falls below this % |
+| `MEMORY_ALERT_USED_PCT` | `90` | DM employee when RAM usage exceeds this % |
+| `ALERT_COOLDOWN_HOURS` | `12` | Minimum hours between repeat disk/memory DMs |
+| `SHUTDOWN_ALERT_COOLDOWN_HOURS` | `4` | Minimum hours between repeat idle-shutdown DMs |
+| `DEBUG_WEBHOOK_URL` | — | Fallback Slack webhook (used if team webhook is missing) |
+| `<TEAM>_TEAM_WEBHOOK_URL` | — | Team channel webhook, e.g. `ML_TEAM_TEAM_WEBHOOK_URL` |
+
+---
+
+## Slack Notifications
+
+### Setup — Slack Bot (recommended)
+
+1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps).
+2. Grant OAuth scopes: `users:read`, `users:read.email`, `im:write`, `chat:write`.
+3. Install to workspace; copy the **Bot User OAuth Token** (`xoxb-…`).
+4. Store it in AWS Secrets Manager as a plaintext secret in `eu-west-1` (or the region set by `GPUMON_SLACK_SECRET_REGION`).
+
+The `Employee` EC2 tag can be an email address (`user@company.com`) for exact lookup, or a display name for fuzzy match. Email is recommended — it's unambiguous and faster.
+
+### Alert types and routing
+
+| Event | Recipient | Cooldown |
+|-------|-----------|---------|
+| Alarm pilot light ON (instance idle, will stop) | Team channel + Employee DM | 4 h per DM |
+| Alarm pilot light OFF (activity resumed) | Team channel only | — |
+| Disk free < `DISK_ALERT_FREE_PCT` | Employee DM | 12 h |
+| Memory used > `MEMORY_ALERT_USED_PCT` | Employee DM | 12 h |
+
+Employee DMs are suppressed when `GPUMON_POLICY=SPOT` or `PAGE_EMPLOYEE=False`.
+
+---
+
+## CloudWatch Metrics
+
+### GPU instances — namespace `GPU-metrics-with-team-tag`
+
+| Metric | Unit | Notes |
+|--------|------|-------|
+| GPU Usage | Percent | Per-GPU utilisation |
+| Memory Usage | Percent | GPU VRAM utilisation |
+| Power Usage (Watts) | None | Via NVML |
+| Temperature (C) | None | Via NVML |
+| Average GPU Utilization | Percent | Mean across all GPUs |
+| Alarm Pilot Light (1/0) | None | 1 = idle threshold crossed |
+| CPU Utilization Low Tripped | None | 1 = CPU below threshold |
+| Network Tripped | None | 1 = network below threshold |
+
+Dimensions: `InstanceId`, `ImageId`, `InstanceType`, `GPUNumber`, `InstanceTag`, `EmployeeTag`
+
+### CPU-only instances — namespace `CPU-metrics`
+
+| Metric | Unit |
+|--------|------|
+| Alarm Pilot Light (1/0) | None |
+| CPU Utilization Low Tripped | None |
+| Network Tripped | None |
+
+Dimensions: `InstanceId`, `ImageId`, `InstanceType`, `InstanceTag`, `EmployeeTag`
+
+### All instances — namespace `Host-metrics`
+
+| Metric | Unit |
+|--------|------|
+| Host Disk Free Bytes | Bytes |
+| Host Disk Free Percent | Percent |
+| Host Memory Used Percent | Percent |
+| Host Top Memory Process Percent | Percent |
+| Host Top CPU Process Percent | Percent |
+
+`Host Top Memory Process Percent` includes a `TopMemoryProcessName` dimension; `Host Top CPU Process Percent` includes `TopCPUProcessName`. Dimensions also include `InstanceId`, `InstanceType`, `InstanceTag`, `EmployeeTag`.
+
+---
+
+## Idle-Shutdown — `halt_it.sh`
+
+`halt_it.sh` runs on the **host** crontab every 10 minutes. It parses the monitor log files in `/tmp` and counts how many consecutive entries have the alarm pilot light set to `1`. If that condition has held for 2 hours, it:
+
+1. Writes a wall message to the terminal.
+2. Fetches stop/terminate credentials from Secrets Manager (`GPUMON_SECRET_ID`).
+3. Calls `aws ec2 stop-instances` or `terminate-instances` depending on policy.
+
+To cancel a pending shutdown, run `/root/gpumon/kill_halt.sh` on the instance — it writes a backoff timestamp that `halt_it.sh` respects for 2 hours.
+
+Log files written by the container are shared with the host via the `/tmp:/tmp` bind-mount, so `halt_it.sh` can read them without entering the container.
+
+---
+
+## Lambda Fleet Manager
+
+`lambda_manager.py` is deployed as an AWS Lambda function (Python 3.12, recommended schedule: every 5–10 minutes via EventBridge).
+
+**IAM permissions required:**
+
+```json
+{
+  "Action": [
+    "ec2:DescribeInstances",
+    "ec2:DescribeTags",
+    "ec2:CreateTags",
+    "ec2:DescribeIamInstanceProfileAssociations",
+    "ec2:AssociateIamInstanceProfile",
+    "ec2:DisassociateIamInstanceProfile",
+    "ssm:SendCommand",
+    "ssm:GetCommandInvocation"
+  ],
+  "Resource": "*"
+}
+```
+
+**SSM timeouts by operation:**
+
+| Operation | `poll_timeout` | `execution_timeout` |
+|-----------|--------------|-------------------|
+| Health check | 30 s | 30 s |
+| Fix (pull + rebuild) | 180 s | 180 s |
+| Install (full Docker) | 900 s | 900 s |
+| Migrate (stop legacy + full Docker) | 1200 s | 1200 s |
+
+**Branch control:**
+
+Set `GPUMON_BRANCH` on an instance to override which git branch is cloned. Defaults:
+
+| Action | Default branch |
+|--------|---------------|
+| `install` | `main` |
+| `MIGRATE` | `feature/dockerize` (update `DOCKER_BRANCH` constant when merged) |
+
+---
+
+## Migration — Legacy to Docker
+
+Instances that ran gpumon directly via systemd (without Docker) continue to work unchanged. When you are ready to migrate a specific instance:
+
+1. Set the `GPUMON` tag to `MIGRATE` (optionally set `GPUMON_BRANCH` if you want a non-default branch).
+2. The Lambda fleet manager will, on the next sweep:
+   - Stop all legacy `gpumon`/`cpumon`/`gpumon-monitor` systemd units.
+   - Kill any directly-running `gpumon.py` / `cpumon.py` / `hostmon.py` processes.
+   - Strip legacy crontab entries.
+   - Re-clone the repo at the target branch.
+   - Run `autoinstall.sh` to install Docker and start the container.
+   - Tag the instance `ACTIVE` on success, `FAILED` on failure.
+
+The `/tmp:/tmp` bind-mount means alert state (`gpumon_alert_state.json`) and log files survive the migration — cooldown timers are preserved.
+
+---
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `gpumon.py` | GPU metrics loop (pynvml → CloudWatch) |
+| `cpumon.py` | CPU-only metrics loop (psutil → CloudWatch) |
+| `hostmon.py` | Host disk/memory metrics + process top (psutil → CloudWatch) |
+| `mon_utils.py` | Shared utilities: IMDS v2, tags, Slack, network stats, crontab, alerting |
+| `slack_dm.py` | Slack Bot DM client (user lookup, channel open, message send) |
+| `halt_it.sh` | Host crontab script: parses logs, stops/terminates idle instances |
+| `kill_halt.sh` | Writes a 2-hour backoff timestamp to cancel a pending shutdown |
+| `autoinstall.sh` | Idempotent Docker installer + halt_it.sh + systemd update timer |
+| `docker-entrypoint.sh` | Detects GPU, launches gpumon.py or cpumon.py + hostmon.py |
+| `Dockerfile` | `nvidia/cuda:12.2.0-base-ubuntu22.04` base, Python 3, boto3, pynvml |
+| `docker-compose.yml` | GPU variant: `network_mode: host`, `pid: host`, `/tmp:/tmp`, all GPUs |
+| `docker-compose.cpu.yml` | CPU override: removes NVIDIA device reservation |
+| `lambda_manager.py` | AWS Lambda fleet manager (SSM, EC2 tags, IAM) |
+| `requirements.txt` | Pinned Python dependencies |
+| `.env.example` | Template for all configurable environment variables |
+
+---
+
+## Development
+
+### Manual Docker commands
+
+```bash
+# GPU instance
+docker compose up -d
+
+# CPU-only instance
+docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
+
+# Rebuild after code change
+docker compose up -d --build
+
+# Logs
+docker logs gpumon-gpumon-1 -f
+
+# Force full reinstall
+sudo rm /var/log/gpumon.finished && sudo bash /root/gpumon/autoinstall.sh
+```
+
+### Branch strategy during Docker rollout
+
+- `main` — legacy (non-Docker) gpumon; existing instances track this branch.
+- `feature/dockerize` — Docker deployment; new installs and migrations use this branch.
+
+When `feature/dockerize` is merged to `main`:
+
+1. Update `DOCKER_BRANCH = "main"` in `lambda_manager.py` and redeploy Lambda.
+2. Retag existing Docker instances (`GPUMON_BRANCH=main`, `GPUMON=MIGRATE`) so they re-clone from `main`.
+3. Delete the `feature/dockerize` branch.
+
+Auto-updates (`gpumon-update.sh`, fired by the systemd timer) pull from whichever branch the instance was cloned at. No special logic is required — git tracks the upstream automatically.
+
+---
+
+## License
+
+Apache License 2.0 — originally from Amazon Web Services, extended by Paul Seifer, Autobrains LTD.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo bash /root/gpumon/autoinstall.sh
 | `GPUMON` | **Yes** | see state machine below | Drives Lambda fleet actions |
 | `GPUMON_BRANCH` | No | default: `feature/dockerize` | Branch to clone during install or migrate; update `DOCKER_BRANCH` constant after merge |
 | `GPUMON_POLICY` | No | `STANDARD` *(default)* | Idle-shutdown sensitivity |
-| `Team` | No | e.g. `ML_TEAM` | Determines Slack team webhook; CloudWatch dimension |
+| `Team` | No | e.g. `ML_TEAM` | CloudWatch dimension |
 | `Employee` | No | Name or `user@email.com` | Slack DM recipient for personal alerts |
 | `PAGE_EMPLOYEE` | No | `True` *(default)* / `False` | Set to `False` to suppress employee DMs |
 | `Name` | No | human-readable name | Used in Slack alert messages instead of instance ID |
@@ -148,8 +148,6 @@ Copy `.env.example` to `.env` in the repo directory before starting the containe
 | `MEMORY_ALERT_USED_PCT` | `90` | DM employee when RAM usage exceeds this % |
 | `ALERT_COOLDOWN_HOURS` | `12` | Minimum hours between repeat disk/memory DMs |
 | `SHUTDOWN_ALERT_COOLDOWN_HOURS` | `4` | Minimum hours between repeat idle-shutdown DMs |
-| `DEBUG_WEBHOOK_URL` | — | Fallback Slack webhook (used if team webhook is missing) |
-| `<TEAM>_TEAM_WEBHOOK_URL` | — | Team channel webhook, e.g. `ML_TEAM_TEAM_WEBHOOK_URL` |
 
 ---
 
@@ -168,8 +166,7 @@ The `Employee` EC2 tag can be an email address (`user@company.com`) for exact lo
 
 | Event | Recipient | Cooldown |
 |-------|-----------|---------|
-| Alarm pilot light ON (instance idle, will stop) | Team channel + Employee DM | 4 h per DM |
-| Alarm pilot light OFF (activity resumed) | Team channel only | — |
+| Alarm pilot light ON (instance idle, will stop) | Employee DM | 4 h |
 | Disk free < `DISK_ALERT_FREE_PCT` | Employee DM | 12 h |
 | Memory used > `MEMORY_ALERT_USED_PCT` | Employee DM | 12 h |
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,14 @@ Dimensions: `InstanceId`, `ImageId`, `InstanceType`, `InstanceTag`, `EmployeeTag
 
 ## Idle-Shutdown — `halt_it.sh`
 
-`halt_it.sh` runs on the **host** crontab every 10 minutes. It parses the monitor log files in `/tmp` and counts how many consecutive entries have the alarm pilot light set to `1`. If that condition has held for 2 hours, it:
+`halt_it.sh` runs on the **host** crontab every 10 minutes. It parses the monitor log files in `/tmp` and evaluates all log lines timestamped within the policy window. **Shutdown requires both conditions:**
+
+1. **No activity spike** — every sample in the window shows `Alarm_Pilot_value:1` (GPU/CPU and network all below threshold for the entire window).
+2. **≥ 90% sample coverage** — at least 90% of the expected 10-second samples exist in the window, preventing a brief monitoring gap or a 1-hour-idle / 1-hour-active pattern from triggering a false shutdown.
+
+The policy window is 2 hours for STANDARD / RELAXED / SUSPEND and 15 minutes for SPOT / SEVERE.
+
+If both conditions are met, `halt_it.sh`:
 
 1. Writes a wall message to the terminal.
 2. Fetches stop/terminate credentials from Secrets Manager (`GPUMON_SECRET_ID`).

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -43,11 +43,11 @@ if command -v nvidia-smi &>/dev/null \
     HAS_GPU=true
 fi
 
-if $HAS_GPU; then
+if $HAS_GPU && ! dpkg -l nvidia-container-toolkit &>/dev/null 2>&1; then
     echo "[autoinstall] GPU detected — installing NVIDIA Container Toolkit..."
     distribution=$(. /etc/os-release && echo "${ID}${VERSION_ID}")
     curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
-        | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+        | gpg --batch --no-tty --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
     curl -fsSL "https://nvidia.github.io/libnvidia-container/${distribution}/libnvidia-container.list" \
         | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
         | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
@@ -56,6 +56,8 @@ if $HAS_GPU; then
     nvidia-ctk runtime configure --runtime=docker
     systemctl restart docker
     timeout 30 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+elif $HAS_GPU; then
+    echo "[autoinstall] NVIDIA Container Toolkit already installed — skipping"
 fi
 
 # ── .env warning ──────────────────────────────────────────────────────────────

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -17,7 +17,7 @@ echo "[autoinstall] Starting gpumon installation from $REPO_DIR"
 
 # ── System packages ───────────────────────────────────────────────────────────
 apt-get update -q
-apt-get install -y git cron curl
+apt-get install -y git cron curl gnupg ca-certificates
 
 # ── Docker ────────────────────────────────────────────────────────────────────
 if ! command -v docker &>/dev/null; then

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -26,6 +26,11 @@ while fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-fronte
     sleep 5
 done
 
+# ── Remove stale third-party repos that poison apt-get update ────────────────
+# GHA runner AMIs ship a kubic/libcontainers repo whose GPG key expires, causing
+# "unable to locate package docker-compose-plugin" even when the repo is reachable.
+rm -f /etc/apt/sources.list.d/*kubic* /etc/apt/sources.list.d/*libcontainers* 2>/dev/null || true
+
 # ── System packages ───────────────────────────────────────────────────────────
 apt-get -o DPkg::Lock::Timeout=120 update -q
 apt-get -o DPkg::Lock::Timeout=120 install -y git cron curl gnupg ca-certificates

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -159,7 +159,23 @@ cd "\$REPO_DIR"
 if command -v nvidia-smi &>/dev/null \\
         && nvidia-smi --list-gpus >/dev/null 2>&1 \\
         && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
-    echo "[\$(date)] gpumon-boot: GPU detected — ensuring GPU compose"
+    echo "[\$(date)] gpumon-boot: GPU detected"
+    # Install NVIDIA Container Toolkit if missing (handles CPU→GPU instance type change).
+    if ! dpkg -l nvidia-container-toolkit >/dev/null 2>&1; then
+        echo "[\$(date)] gpumon-boot: NVIDIA Container Toolkit missing — installing..."
+        distribution=\$(. /etc/os-release && echo "\${ID}\${VERSION_ID}")
+        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \\
+            | gpg --batch --no-tty --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+        curl -fsSL "https://nvidia.github.io/libnvidia-container/\${distribution}/libnvidia-container.list" \\
+            | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \\
+            | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+        apt-get -o DPkg::Lock::Timeout=120 update -q
+        apt-get -o DPkg::Lock::Timeout=120 install -y nvidia-container-toolkit
+        nvidia-ctk runtime configure --runtime=docker
+        systemctl restart docker
+        timeout 30 bash -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
+    fi
+    echo "[\$(date)] gpumon-boot: ensuring GPU compose"
     docker compose up -d
 else
     echo "[\$(date)] gpumon-boot: no GPU — ensuring CPU compose"
@@ -192,7 +208,7 @@ echo "[autoinstall] Boot reconciliation service enabled"
 cat > /etc/systemd/system/gpumon-update.service << 'EOF'
 [Unit]
 Description=gpumon auto-update
-After=network-online.target
+After=network-online.target gpumon-boot.service
 Wants=network-online.target
 
 [Service]

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -74,44 +74,19 @@ if [ -f "${REPO_DIR}/.env" ]; then
 else
     echo "[autoinstall] .env not found — generating from Secrets Manager..."
 
-    _IMDSv2_TOKEN=$(curl -s --max-time 5 -X PUT "http://169.254.169.254/latest/api/token" \
-        -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null)
-    _REGION=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $_IMDSv2_TOKEN" \
-        http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null)
-    _INSTANCE_ID=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $_IMDSv2_TOKEN" \
-        http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
-    _TEAM=$(aws ec2 describe-tags \
-        --filters "Name=resource-id,Values=${_INSTANCE_ID}" "Name=key,Values=Team" \
-        --query "Tags[0].Value" --output text --region "${_REGION}" 2>/dev/null || true)
-
     # Secret IDs — callers may override via env vars before invoking autoinstall.sh
     _SLACK_SECRET_ID="${GPUMON_SLACK_SECRET_ID:-IT/SLACK_BOT_TOKEN}"
     _SLACK_SECRET_REGION="${GPUMON_SLACK_SECRET_REGION:-eu-west-1}"
     _INST_SECRET_ID="${GPUMON_SECRET_ID:-AB/InstanceRole}"
     _INST_SECRET_REGION="${GPUMON_SECRET_REGION:-eu-west-1}"
 
-    # Team webhook (e.g. IT/TEAM/IT_TEAM_WEBHOOK_URL); fall back to debug webhook
-    _TEAM_WEBHOOK=""
-    if [ -n "$_TEAM" ] && [ "$_TEAM" != "None" ]; then
-        _TEAM_WEBHOOK=$(aws secretsmanager get-secret-value \
-            --secret-id "IT/TEAM/${_TEAM}_TEAM_WEBHOOK_URL" \
-            --query "SecretString" --output text --region "${_REGION}" 2>/dev/null || true)
-        [ "$_TEAM_WEBHOOK" = "None" ] && _TEAM_WEBHOOK=""
-    fi
-    _DEBUG_WEBHOOK=$(aws secretsmanager get-secret-value \
-        --secret-id "IT/TEAM/DEBUG_WEBHOOK_URL" \
-        --query "SecretString" --output text --region "${_REGION}" 2>/dev/null || true)
-    [ "$_DEBUG_WEBHOOK" = "None" ] && _DEBUG_WEBHOOK=""
-
     {
         echo "GPUMON_SLACK_SECRET_ID=${_SLACK_SECRET_ID}"
         echo "GPUMON_SLACK_SECRET_REGION=${_SLACK_SECRET_REGION}"
         echo "GPUMON_SECRET_ID=${_INST_SECRET_ID}"
         echo "GPUMON_SECRET_REGION=${_INST_SECRET_REGION}"
-        [ -n "$_DEBUG_WEBHOOK" ]  && echo "DEBUG_WEBHOOK_URL=${_DEBUG_WEBHOOK}"
-        [ -n "$_TEAM_WEBHOOK" ]   && echo "${_TEAM}_TEAM_WEBHOOK_URL=${_TEAM_WEBHOOK}"
     } > "${REPO_DIR}/.env"
-    echo "[autoinstall] .env written (team: ${_TEAM:-unknown}, debug_webhook: ${_DEBUG_WEBHOOK:+set})"
+    echo "[autoinstall] .env written"
 fi
 
 # ── Build and start container ─────────────────────────────────────────────────

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -132,8 +132,9 @@ if $HAS_GPU; then
     # restarts; NVML fails inside the container on first start if the OCI prestart
     # hook fires before the runtime is ready.  One restart always resolves it.
     sleep 8
-    if ! docker exec gpumon-gpumon-1 nvidia-smi --list-gpus >/dev/null 2>&1; then
-        echo "[autoinstall] NVML not ready — recreating container to re-run OCI prestart hook..."
+    _nvml_out=$(docker exec gpumon-gpumon-1 nvidia-smi --list-gpus 2>&1 || true)
+    if echo "$_nvml_out" | grep -qi "failed\|error\|unknown"; then
+        echo "[autoinstall] NVML not ready (${_nvml_out}) — recreating container to re-run OCI prestart hook..."
         docker compose down && docker compose up -d
         sleep 5
     fi

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -3,6 +3,9 @@
 # Idempotent: re-running is safe.  Remove /var/log/gpumon.finished to reinstall.
 set -euo pipefail
 
+# Suppress needrestart prompts on Ubuntu 24.04+ (no-op on older distros).
+export NEEDRESTART_MODE=a
+
 REPO_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 SENTINEL="/var/log/gpumon.finished"
 HALT_HOST="/usr/local/sbin/halt_it.sh"

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -124,13 +124,13 @@ else
 fi
 
 # ── Build and start container ─────────────────────────────────────────────────
+# Use up --build rather than separate build + up: standalone "docker compose build"
+# exits non-zero on some Compose v5 hosts (getwd bug) even when the image is built.
 cd "$REPO_DIR"
 if $HAS_GPU; then
-    docker compose build
-    docker compose up -d
+    docker compose up -d --build
 else
-    docker compose -f docker-compose.cpu.yml build
-    docker compose -f docker-compose.cpu.yml up -d
+    docker compose -f docker-compose.cpu.yml up -d --build
 fi
 
 echo "[autoinstall] Container started:"

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -77,6 +77,15 @@ cat > "${BOOT_SCRIPT}" << BOOTSCRIPT
 set -euo pipefail
 REPO_DIR="${REPO_DIR}"
 cd "\$REPO_DIR"
+
+# The legacy gpumon.service (pre-Docker) runs early at boot before Docker is ready.
+# Stop and disable it so it doesn't run alongside the Docker container.
+systemctl stop gpumon.service 2>/dev/null || true
+systemctl disable gpumon.service 2>/dev/null || true
+pkill -f "python3 /root/gpumon/gpumon.py" 2>/dev/null || true
+pkill -f "python3 /root/gpumon/cpumon.py" 2>/dev/null || true
+pkill -f "python3 /root/gpumon/hostmon.py" 2>/dev/null || true
+
 if command -v nvidia-smi &>/dev/null \\
         && nvidia-smi --list-gpus >/dev/null 2>&1 \\
         && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -15,6 +15,13 @@ fi
 
 echo "[autoinstall] Starting gpumon installation from $REPO_DIR"
 
+# ── Stop automatic update services so they don't hold the apt lock ───────────
+systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+while fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend /var/cache/apt/archives/lock >/dev/null 2>&1; do
+    echo "[autoinstall] waiting for apt lock..."
+    sleep 5
+done
+
 # ── System packages ───────────────────────────────────────────────────────────
 apt-get -o DPkg::Lock::Timeout=120 update -q
 apt-get -o DPkg::Lock::Timeout=120 install -y git cron curl gnupg ca-certificates

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -131,10 +131,10 @@ if $HAS_GPU; then
     # nvidia-container-runtime can take a moment to fully initialize after Docker
     # restarts; NVML fails inside the container on first start if the OCI prestart
     # hook fires before the runtime is ready.  One restart always resolves it.
-    sleep 5
+    sleep 8
     if ! docker exec gpumon-gpumon-1 nvidia-smi --list-gpus >/dev/null 2>&1; then
-        echo "[autoinstall] NVML not ready — restarting container once..."
-        docker compose restart
+        echo "[autoinstall] NVML not ready — recreating container to re-run OCI prestart hook..."
+        docker compose down && docker compose up -d
         sleep 5
     fi
 else

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -16,8 +16,8 @@ fi
 echo "[autoinstall] Starting gpumon installation from $REPO_DIR"
 
 # ── System packages ───────────────────────────────────────────────────────────
-apt-get update -q
-apt-get install -y git cron curl gnupg ca-certificates
+apt-get -o DPkg::Lock::Timeout=120 update -q
+apt-get -o DPkg::Lock::Timeout=120 install -y git cron curl gnupg ca-certificates
 
 # ── Docker ────────────────────────────────────────────────────────────────────
 if ! command -v docker &>/dev/null; then
@@ -28,7 +28,7 @@ fi
 
 if ! docker compose version &>/dev/null; then
     echo "[autoinstall] Installing docker compose plugin..."
-    apt-get install -y docker-compose-plugin
+    apt-get -o DPkg::Lock::Timeout=120 install -y docker-compose-plugin
 fi
 
 # Wait up to 30 s for Docker daemon
@@ -51,8 +51,8 @@ if $HAS_GPU; then
     curl -fsSL "https://nvidia.github.io/libnvidia-container/${distribution}/libnvidia-container.list" \
         | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
         | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-    apt-get update -q
-    apt-get install -y nvidia-container-toolkit
+    apt-get -o DPkg::Lock::Timeout=120 update -q
+    apt-get -o DPkg::Lock::Timeout=120 install -y nvidia-container-toolkit
     nvidia-ctk runtime configure --runtime=docker
     systemctl restart docker
     timeout 30 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -182,6 +182,13 @@ if command -v nvidia-smi &>/dev/null \\
         && nvidia-smi --list-gpus >/dev/null 2>&1 \\
         && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
     docker compose up -d --build
+    sleep 8
+    _nvml_out=\$(docker exec gpumon-gpumon-1 nvidia-smi --list-gpus 2>&1 || true)
+    if echo "\$_nvml_out" | grep -qi "failed\|error\|unknown"; then
+        echo "[\$(date)] gpumon-update: NVML not ready (\${_nvml_out}) — recreating container..."
+        docker compose down && docker compose up -d
+        sleep 5
+    fi
 else
     docker compose -f docker-compose.cpu.yml up -d --build
 fi
@@ -223,6 +230,13 @@ if command -v nvidia-smi &>/dev/null \\
     fi
     echo "[\$(date)] gpumon-boot: ensuring GPU compose"
     docker compose up -d
+    sleep 8
+    _nvml_out=\$(docker exec gpumon-gpumon-1 nvidia-smi --list-gpus 2>&1 || true)
+    if echo "\$_nvml_out" | grep -qi "failed\|error\|unknown"; then
+        echo "[\$(date)] gpumon-boot: NVML not ready (\${_nvml_out}) — recreating container..."
+        docker compose down && docker compose up -d
+        sleep 5
+    fi
 else
     echo "[\$(date)] gpumon-boot: no GPU — ensuring CPU compose"
     docker compose -f docker-compose.cpu.yml up -d

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -96,8 +96,8 @@ if $HAS_GPU; then
     docker compose build
     docker compose up -d
 else
-    docker compose -f docker-compose.yml -f docker-compose.cpu.yml build
-    docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
+    docker compose -f docker-compose.cpu.yml build
+    docker compose -f docker-compose.cpu.yml up -d
 fi
 
 echo "[autoinstall] Container started:"
@@ -141,7 +141,7 @@ if command -v nvidia-smi &>/dev/null \\
         && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
     docker compose up -d --build
 else
-    docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d --build
+    docker compose -f docker-compose.cpu.yml up -d --build
 fi
 echo "[\$(date)] gpumon-update: done"
 UPDATESCRIPT
@@ -184,7 +184,7 @@ if command -v nvidia-smi &>/dev/null \\
     docker compose up -d
 else
     echo "[\$(date)] gpumon-boot: no GPU — ensuring CPU compose"
-    docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
+    docker compose -f docker-compose.cpu.yml up -d
 fi
 BOOTSCRIPT
 chmod +x "${BOOT_SCRIPT}"

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -78,7 +78,7 @@ fi
 if $HAS_GPU && ! dpkg -l nvidia-container-toolkit &>/dev/null 2>&1; then
     echo "[autoinstall] GPU detected — installing NVIDIA Container Toolkit..."
     curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
-        | gpg --batch --no-tty --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+        | gpg --batch --no-tty --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
     curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
         | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
         | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
@@ -201,7 +201,7 @@ if command -v nvidia-smi &>/dev/null \\
             sleep 5
         done
         curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \\
-            | gpg --batch --no-tty --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+            | gpg --batch --no-tty --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
         curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \\
             | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \\
             | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -77,10 +77,9 @@ fi
 
 if $HAS_GPU && ! dpkg -l nvidia-container-toolkit &>/dev/null 2>&1; then
     echo "[autoinstall] GPU detected — installing NVIDIA Container Toolkit..."
-    distribution=$(. /etc/os-release && echo "${ID}${VERSION_ID}")
     curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
         | gpg --batch --no-tty --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-    curl -fsSL "https://nvidia.github.io/libnvidia-container/${distribution}/libnvidia-container.list" \
+    curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
         | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
         | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
     apt-get -o DPkg::Lock::Timeout=120 update -q
@@ -201,10 +200,9 @@ if command -v nvidia-smi &>/dev/null \\
             echo "[\$(date)] gpumon-boot: waiting for apt lock..."
             sleep 5
         done
-        distribution=\$(. /etc/os-release && echo "\${ID}\${VERSION_ID}")
         curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \\
             | gpg --batch --no-tty --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-        curl -fsSL "https://nvidia.github.io/libnvidia-container/\${distribution}/libnvidia-container.list" \\
+        curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \\
             | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \\
             | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
         apt-get -o DPkg::Lock::Timeout=120 update -q

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -128,6 +128,15 @@ fi
 cd "$REPO_DIR"
 if $HAS_GPU; then
     docker compose up -d --build
+    # nvidia-container-runtime can take a moment to fully initialize after Docker
+    # restarts; NVML fails inside the container on first start if the OCI prestart
+    # hook fires before the runtime is ready.  One restart always resolves it.
+    sleep 5
+    if ! docker exec gpumon-gpumon-1 nvidia-smi --list-gpus >/dev/null 2>&1; then
+        echo "[autoinstall] NVML not ready — restarting container once..."
+        docker compose restart
+        sleep 5
+    fi
 else
     docker compose -f docker-compose.cpu.yml up -d --build
 fi

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -95,7 +95,8 @@ set -euo pipefail
 REPO_DIR="${REPO_DIR}"
 
 BEFORE=\$(git -C "\$REPO_DIR" rev-parse HEAD)
-git -C "\$REPO_DIR" pull --force --quiet
+git -C "\$REPO_DIR" fetch origin --quiet
+git -C "\$REPO_DIR" reset --hard @{upstream} --quiet
 AFTER=\$(git -C "\$REPO_DIR" rev-parse HEAD)
 
 if [ "\$BEFORE" = "\$AFTER" ]; then

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -163,6 +163,11 @@ if command -v nvidia-smi &>/dev/null \\
     # Install NVIDIA Container Toolkit if missing (handles CPU→GPU instance type change).
     if ! dpkg -l nvidia-container-toolkit >/dev/null 2>&1; then
         echo "[\$(date)] gpumon-boot: NVIDIA Container Toolkit missing — installing..."
+        systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+        while fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend /var/cache/apt/archives/lock >/dev/null 2>&1; do
+            echo "[\$(date)] gpumon-boot: waiting for apt lock..."
+            sleep 5
+        done
         distribution=\$(. /etc/os-release && echo "\${ID}\${VERSION_ID}")
         curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \\
             | gpg --batch --no-tty --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -42,6 +42,22 @@ if ! command -v docker &>/dev/null; then
     systemctl enable --now docker
 fi
 
+# GHA runner AMIs ship Docker from the Ubuntu universe repo without adding
+# Docker's official apt repo.  docker-compose-plugin only exists in Docker's
+# repo, so add it if it isn't already present.
+if ! grep -rq "download.docker.com" /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null; then
+    echo "[autoinstall] Adding Docker official apt repo..."
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+        | gpg --batch --no-tty --dearmor -o /etc/apt/keyrings/docker.gpg
+    chmod a+r /etc/apt/keyrings/docker.gpg
+    _arch=$(dpkg --print-architecture)
+    _codename=$(. /etc/os-release && echo "$VERSION_CODENAME")
+    echo "deb [arch=${_arch} signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu ${_codename} stable" \
+        | tee /etc/apt/sources.list.d/docker.list > /dev/null
+    apt-get -o DPkg::Lock::Timeout=120 update -q
+fi
+
 if ! docker compose version &>/dev/null; then
     echo "[autoinstall] Installing docker compose plugin..."
     apt-get -o DPkg::Lock::Timeout=120 install -y docker-compose-plugin

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -89,7 +89,16 @@ if $HAS_GPU && ! dpkg -l nvidia-container-toolkit &>/dev/null 2>&1; then
     systemctl restart docker
     timeout 30 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
 elif $HAS_GPU; then
-    echo "[autoinstall] NVIDIA Container Toolkit already installed — skipping"
+    echo "[autoinstall] NVIDIA Container Toolkit already installed"
+    # Re-run configure if the nvidia runtime is missing from Docker.
+    # This handles a partial prior run that installed the toolkit but was
+    # interrupted before nvidia-ctk runtime configure / docker restart.
+    if ! docker info --format '{{range $k, $v := .Runtimes}}{{$k}} {{end}}' 2>/dev/null | grep -qw nvidia; then
+        echo "[autoinstall] Registering nvidia Docker runtime..."
+        nvidia-ctk runtime configure --runtime=docker
+        systemctl restart docker
+        timeout 30 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+    fi
 fi
 
 # ── Auto-generate .env from Secrets Manager if not present ────────────────────

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -67,9 +67,51 @@ elif $HAS_GPU; then
     echo "[autoinstall] NVIDIA Container Toolkit already installed — skipping"
 fi
 
-# ── .env warning ──────────────────────────────────────────────────────────────
-if [ ! -f "${REPO_DIR}/.env" ]; then
-    echo "[autoinstall] WARNING: .env not found. Copy .env.example to .env and fill in Slack webhooks."
+# ── Auto-generate .env from Secrets Manager if not present ────────────────────
+# Never overwrites an existing .env so manual configuration is preserved.
+if [ -f "${REPO_DIR}/.env" ]; then
+    echo "[autoinstall] .env already exists — skipping auto-generation"
+else
+    echo "[autoinstall] .env not found — generating from Secrets Manager..."
+
+    _IMDSv2_TOKEN=$(curl -s --max-time 5 -X PUT "http://169.254.169.254/latest/api/token" \
+        -H "X-aws-ec2-metadata-token-ttl-seconds: 60" 2>/dev/null)
+    _REGION=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $_IMDSv2_TOKEN" \
+        http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null)
+    _INSTANCE_ID=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $_IMDSv2_TOKEN" \
+        http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
+    _TEAM=$(aws ec2 describe-tags \
+        --filters "Name=resource-id,Values=${_INSTANCE_ID}" "Name=key,Values=Team" \
+        --query "Tags[0].Value" --output text --region "${_REGION}" 2>/dev/null || true)
+
+    # Secret IDs — callers may override via env vars before invoking autoinstall.sh
+    _SLACK_SECRET_ID="${GPUMON_SLACK_SECRET_ID:-IT/SLACK_BOT_TOKEN}"
+    _SLACK_SECRET_REGION="${GPUMON_SLACK_SECRET_REGION:-eu-west-1}"
+    _INST_SECRET_ID="${GPUMON_SECRET_ID:-AB/InstanceRole}"
+    _INST_SECRET_REGION="${GPUMON_SECRET_REGION:-eu-west-1}"
+
+    # Team webhook (e.g. IT/TEAM/IT_TEAM_WEBHOOK_URL); fall back to debug webhook
+    _TEAM_WEBHOOK=""
+    if [ -n "$_TEAM" ] && [ "$_TEAM" != "None" ]; then
+        _TEAM_WEBHOOK=$(aws secretsmanager get-secret-value \
+            --secret-id "IT/TEAM/${_TEAM}_TEAM_WEBHOOK_URL" \
+            --query "SecretString" --output text --region "${_REGION}" 2>/dev/null || true)
+        [ "$_TEAM_WEBHOOK" = "None" ] && _TEAM_WEBHOOK=""
+    fi
+    _DEBUG_WEBHOOK=$(aws secretsmanager get-secret-value \
+        --secret-id "IT/TEAM/DEBUG_WEBHOOK_URL" \
+        --query "SecretString" --output text --region "${_REGION}" 2>/dev/null || true)
+    [ "$_DEBUG_WEBHOOK" = "None" ] && _DEBUG_WEBHOOK=""
+
+    {
+        echo "GPUMON_SLACK_SECRET_ID=${_SLACK_SECRET_ID}"
+        echo "GPUMON_SLACK_SECRET_REGION=${_SLACK_SECRET_REGION}"
+        echo "GPUMON_SECRET_ID=${_INST_SECRET_ID}"
+        echo "GPUMON_SECRET_REGION=${_INST_SECRET_REGION}"
+        [ -n "$_DEBUG_WEBHOOK" ]  && echo "DEBUG_WEBHOOK_URL=${_DEBUG_WEBHOOK}"
+        [ -n "$_TEAM_WEBHOOK" ]   && echo "${_TEAM}_TEAM_WEBHOOK_URL=${_TEAM_WEBHOOK}"
+    } > "${REPO_DIR}/.env"
+    echo "[autoinstall] .env written (team: ${_TEAM:-unknown}, debug_webhook: ${_DEBUG_WEBHOOK:+set})"
 fi
 
 # ── Build and start container ─────────────────────────────────────────────────

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -12,8 +12,160 @@ HALT_HOST="/usr/local/sbin/halt_it.sh"
 UPDATE_SCRIPT="/usr/local/sbin/gpumon-update.sh"
 BOOT_SCRIPT="/usr/local/sbin/gpumon-boot.sh"
 
+# ── Service/script files (always refreshed, even on re-runs) ─────────────────
+# These run before the sentinel check so every Lambda-triggered re-run updates
+# halt_it.sh, gpumon-boot.sh, and gpumon-update.sh regardless of install state.
+# Fixes: old installs (sentinel exists) kept stale gpumon-boot.sh and missed the
+# NVML OCI-hook fix that was added after their initial installation.
+
+cp "${REPO_DIR}/halt_it.sh" "${HALT_HOST}"
+chmod +x "${HALT_HOST}"
+
+CRON_JOB="*/10 * * * * ${HALT_HOST} >> /var/log/halt_it.log 2>&1"
+if ! crontab -l 2>/dev/null | grep -q "halt_it.sh"; then
+    ( crontab -l 2>/dev/null; echo "$CRON_JOB" ) | crontab -
+    echo "[autoinstall] halt_it.sh cron job installed"
+else
+    echo "[autoinstall] halt_it.sh already in crontab"
+fi
+
+# ── Auto-update script ────────────────────────────────────────────────────────
+cat > "${UPDATE_SCRIPT}" << UPDATESCRIPT
+#!/bin/bash
+set -euo pipefail
+REPO_DIR="${REPO_DIR}"
+
+BEFORE=\$(git -C "\$REPO_DIR" rev-parse HEAD)
+git -C "\$REPO_DIR" fetch origin --quiet
+git -C "\$REPO_DIR" reset --hard @{upstream} --quiet
+AFTER=\$(git -C "\$REPO_DIR" rev-parse HEAD)
+
+if [ "\$BEFORE" = "\$AFTER" ]; then
+    echo "[\$(date)] gpumon-update: no changes"
+    exit 0
+fi
+
+echo "[\$(date)] gpumon-update: \$BEFORE -> \$AFTER — rebuilding container"
+cp "\${REPO_DIR}/halt_it.sh" "${HALT_HOST}"
+chmod +x "${HALT_HOST}"
+
+cd "\$REPO_DIR"
+if command -v nvidia-smi &>/dev/null \\
+        && nvidia-smi --list-gpus >/dev/null 2>&1 \\
+        && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
+    docker compose up -d --build
+    sleep 8
+    _nvml_out=\$(docker exec gpumon-gpumon-1 nvidia-smi --list-gpus 2>&1 || true)
+    if echo "\$_nvml_out" | grep -qi "failed\|error\|unknown"; then
+        echo "[\$(date)] gpumon-update: NVML not ready (\${_nvml_out}) — recreating container..."
+        docker compose down && docker compose up -d
+        sleep 5
+    fi
+else
+    docker compose -f docker-compose.cpu.yml up -d --build
+fi
+echo "[\$(date)] gpumon-update: done"
+UPDATESCRIPT
+chmod +x "${UPDATE_SCRIPT}"
+
+# ── Boot reconciliation service ───────────────────────────────────────────────
+# Runs once after Docker starts on every boot.  Detects GPU presence and calls
+# docker compose up -d with the correct config so the container is always right
+# regardless of instance type changes (GPU ↔ CPU).  No image rebuild — fast.
+cat > "${BOOT_SCRIPT}" << BOOTSCRIPT
+#!/bin/bash
+set -euo pipefail
+REPO_DIR="${REPO_DIR}"
+cd "\$REPO_DIR"
+if command -v nvidia-smi &>/dev/null \\
+        && nvidia-smi --list-gpus >/dev/null 2>&1 \\
+        && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
+    echo "[\$(date)] gpumon-boot: GPU detected"
+    # Install NVIDIA Container Toolkit if missing (handles CPU→GPU instance type change).
+    if ! dpkg -l nvidia-container-toolkit >/dev/null 2>&1; then
+        echo "[\$(date)] gpumon-boot: NVIDIA Container Toolkit missing — installing..."
+        systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
+        while fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend /var/cache/apt/archives/lock >/dev/null 2>&1; do
+            echo "[\$(date)] gpumon-boot: waiting for apt lock..."
+            sleep 5
+        done
+        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \\
+            | gpg --batch --no-tty --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+        curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \\
+            | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \\
+            | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+        apt-get -o DPkg::Lock::Timeout=120 update -q
+        apt-get -o DPkg::Lock::Timeout=120 install -y nvidia-container-toolkit
+        nvidia-ctk runtime configure --runtime=docker
+        systemctl restart docker
+        timeout 30 bash -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
+    fi
+    echo "[\$(date)] gpumon-boot: ensuring GPU compose"
+    docker compose up -d
+    sleep 8
+    _nvml_out=\$(docker exec gpumon-gpumon-1 nvidia-smi --list-gpus 2>&1 || true)
+    if echo "\$_nvml_out" | grep -qi "failed\|error\|unknown"; then
+        echo "[\$(date)] gpumon-boot: NVML not ready (\${_nvml_out}) — recreating container..."
+        docker compose down && docker compose up -d
+        sleep 5
+    fi
+else
+    echo "[\$(date)] gpumon-boot: no GPU — ensuring CPU compose"
+    docker compose -f docker-compose.cpu.yml up -d
+fi
+BOOTSCRIPT
+chmod +x "${BOOT_SCRIPT}"
+
+cat > /etc/systemd/system/gpumon-boot.service << 'EOF'
+[Unit]
+Description=gpumon boot-time container reconciliation
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/gpumon-boot.sh
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > /etc/systemd/system/gpumon-update.service << 'EOF'
+[Unit]
+Description=gpumon auto-update
+After=network-online.target gpumon-boot.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/gpumon-update.sh
+StandardOutput=journal
+StandardError=journal
+EOF
+
+cat > /etc/systemd/system/gpumon-update.timer << 'EOF'
+[Unit]
+Description=gpumon auto-update timer
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable gpumon-boot.service
+systemctl enable --now gpumon-update.timer
+echo "[autoinstall] Service files refreshed"
+
+# ── Early exit if already fully installed ────────────────────────────────────
 if [ -f "$SENTINEL" ]; then
-    echo "[autoinstall] Already installed. Remove $SENTINEL to reinstall."
+    echo "[autoinstall] Already installed (service files refreshed above). Remove $SENTINEL to reinstall."
     exit 0
 fi
 
@@ -144,155 +296,6 @@ fi
 
 echo "[autoinstall] Container started:"
 docker ps --filter "name=gpumon" --format "  {{.Names}}  {{.Status}}"
-
-# ── halt_it.sh on host crontab ────────────────────────────────────────────────
-cp "${REPO_DIR}/halt_it.sh" "${HALT_HOST}"
-chmod +x "${HALT_HOST}"
-
-CRON_JOB="*/10 * * * * ${HALT_HOST} >> /var/log/halt_it.log 2>&1"
-if ! crontab -l 2>/dev/null | grep -q "halt_it.sh"; then
-    ( crontab -l 2>/dev/null; echo "$CRON_JOB" ) | crontab -
-    echo "[autoinstall] halt_it.sh cron job installed"
-else
-    echo "[autoinstall] halt_it.sh already in crontab"
-fi
-
-# ── Auto-update script ────────────────────────────────────────────────────────
-cat > "${UPDATE_SCRIPT}" << UPDATESCRIPT
-#!/bin/bash
-set -euo pipefail
-REPO_DIR="${REPO_DIR}"
-
-BEFORE=\$(git -C "\$REPO_DIR" rev-parse HEAD)
-git -C "\$REPO_DIR" fetch origin --quiet
-git -C "\$REPO_DIR" reset --hard @{upstream} --quiet
-AFTER=\$(git -C "\$REPO_DIR" rev-parse HEAD)
-
-if [ "\$BEFORE" = "\$AFTER" ]; then
-    echo "[\$(date)] gpumon-update: no changes"
-    exit 0
-fi
-
-echo "[\$(date)] gpumon-update: \$BEFORE -> \$AFTER — rebuilding container"
-cp "\${REPO_DIR}/halt_it.sh" "${HALT_HOST}"
-chmod +x "${HALT_HOST}"
-
-cd "\$REPO_DIR"
-if command -v nvidia-smi &>/dev/null \\
-        && nvidia-smi --list-gpus >/dev/null 2>&1 \\
-        && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
-    docker compose up -d --build
-    sleep 8
-    _nvml_out=\$(docker exec gpumon-gpumon-1 nvidia-smi --list-gpus 2>&1 || true)
-    if echo "\$_nvml_out" | grep -qi "failed\|error\|unknown"; then
-        echo "[\$(date)] gpumon-update: NVML not ready (\${_nvml_out}) — recreating container..."
-        docker compose down && docker compose up -d
-        sleep 5
-    fi
-else
-    docker compose -f docker-compose.cpu.yml up -d --build
-fi
-echo "[\$(date)] gpumon-update: done"
-UPDATESCRIPT
-chmod +x "${UPDATE_SCRIPT}"
-
-# ── Boot reconciliation service ───────────────────────────────────────────────
-# Runs once after Docker starts on every boot.  Detects GPU presence and calls
-# docker compose up -d with the correct config so the container is always right
-# regardless of instance type changes (GPU ↔ CPU).  No image rebuild — fast.
-cat > "${BOOT_SCRIPT}" << BOOTSCRIPT
-#!/bin/bash
-set -euo pipefail
-REPO_DIR="${REPO_DIR}"
-cd "\$REPO_DIR"
-if command -v nvidia-smi &>/dev/null \\
-        && nvidia-smi --list-gpus >/dev/null 2>&1 \\
-        && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
-    echo "[\$(date)] gpumon-boot: GPU detected"
-    # Install NVIDIA Container Toolkit if missing (handles CPU→GPU instance type change).
-    if ! dpkg -l nvidia-container-toolkit >/dev/null 2>&1; then
-        echo "[\$(date)] gpumon-boot: NVIDIA Container Toolkit missing — installing..."
-        systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true
-        while fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend /var/cache/apt/archives/lock >/dev/null 2>&1; do
-            echo "[\$(date)] gpumon-boot: waiting for apt lock..."
-            sleep 5
-        done
-        curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \\
-            | gpg --batch --no-tty --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-        curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \\
-            | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \\
-            | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-        apt-get -o DPkg::Lock::Timeout=120 update -q
-        apt-get -o DPkg::Lock::Timeout=120 install -y nvidia-container-toolkit
-        nvidia-ctk runtime configure --runtime=docker
-        systemctl restart docker
-        timeout 30 bash -c 'until docker info >/dev/null 2>&1; do sleep 1; done'
-    fi
-    echo "[\$(date)] gpumon-boot: ensuring GPU compose"
-    docker compose up -d
-    sleep 8
-    _nvml_out=\$(docker exec gpumon-gpumon-1 nvidia-smi --list-gpus 2>&1 || true)
-    if echo "\$_nvml_out" | grep -qi "failed\|error\|unknown"; then
-        echo "[\$(date)] gpumon-boot: NVML not ready (\${_nvml_out}) — recreating container..."
-        docker compose down && docker compose up -d
-        sleep 5
-    fi
-else
-    echo "[\$(date)] gpumon-boot: no GPU — ensuring CPU compose"
-    docker compose -f docker-compose.cpu.yml up -d
-fi
-BOOTSCRIPT
-chmod +x "${BOOT_SCRIPT}"
-
-cat > /etc/systemd/system/gpumon-boot.service << 'EOF'
-[Unit]
-Description=gpumon boot-time container reconciliation
-After=docker.service
-Requires=docker.service
-
-[Service]
-Type=oneshot
-ExecStart=/usr/local/sbin/gpumon-boot.sh
-StandardOutput=journal
-StandardError=journal
-
-[Install]
-WantedBy=multi-user.target
-EOF
-
-systemctl daemon-reload
-systemctl enable gpumon-boot.service
-echo "[autoinstall] Boot reconciliation service enabled"
-
-# ── Systemd timer for hourly auto-updates ─────────────────────────────────────
-cat > /etc/systemd/system/gpumon-update.service << 'EOF'
-[Unit]
-Description=gpumon auto-update
-After=network-online.target gpumon-boot.service
-Wants=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/local/sbin/gpumon-update.sh
-StandardOutput=journal
-StandardError=journal
-EOF
-
-cat > /etc/systemd/system/gpumon-update.timer << 'EOF'
-[Unit]
-Description=gpumon auto-update timer
-
-[Timer]
-OnBootSec=5min
-OnUnitActiveSec=1h
-Persistent=true
-
-[Install]
-WantedBy=timers.target
-EOF
-
-systemctl daemon-reload
-systemctl enable --now gpumon-update.timer
 
 echo "[autoinstall] Auto-update timer enabled (fires 5 min post-boot, then every 1 h)"
 echo "[autoinstall] Installation complete."

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -7,6 +7,7 @@ REPO_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 SENTINEL="/var/log/gpumon.finished"
 HALT_HOST="/usr/local/sbin/halt_it.sh"
 UPDATE_SCRIPT="/usr/local/sbin/gpumon-update.sh"
+BOOT_SCRIPT="/usr/local/sbin/gpumon-boot.sh"
 
 if [ -f "$SENTINEL" ]; then
     echo "[autoinstall] Already installed. Remove $SENTINEL to reinstall."
@@ -145,6 +146,47 @@ fi
 echo "[\$(date)] gpumon-update: done"
 UPDATESCRIPT
 chmod +x "${UPDATE_SCRIPT}"
+
+# ── Boot reconciliation service ───────────────────────────────────────────────
+# Runs once after Docker starts on every boot.  Detects GPU presence and calls
+# docker compose up -d with the correct config so the container is always right
+# regardless of instance type changes (GPU ↔ CPU).  No image rebuild — fast.
+cat > "${BOOT_SCRIPT}" << BOOTSCRIPT
+#!/bin/bash
+set -euo pipefail
+REPO_DIR="${REPO_DIR}"
+cd "\$REPO_DIR"
+if command -v nvidia-smi &>/dev/null \\
+        && nvidia-smi --list-gpus >/dev/null 2>&1 \\
+        && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
+    echo "[\$(date)] gpumon-boot: GPU detected — ensuring GPU compose"
+    docker compose up -d
+else
+    echo "[\$(date)] gpumon-boot: no GPU — ensuring CPU compose"
+    docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
+fi
+BOOTSCRIPT
+chmod +x "${BOOT_SCRIPT}"
+
+cat > /etc/systemd/system/gpumon-boot.service << 'EOF'
+[Unit]
+Description=gpumon boot-time container reconciliation
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/gpumon-boot.sh
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable gpumon-boot.service
+echo "[autoinstall] Boot reconciliation service enabled"
 
 # ── Systemd timer for hourly auto-updates ─────────────────────────────────────
 cat > /etc/systemd/system/gpumon-update.service << 'EOF'

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# gpumon installer for AWS EC2 — (c) Paul Seifer, Autobrains LTD
+# Idempotent: re-running is safe.  Remove /var/log/gpumon.finished to reinstall.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+SENTINEL="/var/log/gpumon.finished"
+HALT_HOST="/usr/local/sbin/halt_it.sh"
+UPDATE_SCRIPT="/usr/local/sbin/gpumon-update.sh"
+
+if [ -f "$SENTINEL" ]; then
+    echo "[autoinstall] Already installed. Remove $SENTINEL to reinstall."
+    exit 0
+fi
+
+echo "[autoinstall] Starting gpumon installation from $REPO_DIR"
+
+# ── System packages ───────────────────────────────────────────────────────────
+apt-get update -q
+apt-get install -y git cron curl
+
+# ── Docker ────────────────────────────────────────────────────────────────────
+if ! command -v docker &>/dev/null; then
+    echo "[autoinstall] Installing Docker..."
+    curl -fsSL https://get.docker.com | sh
+    systemctl enable --now docker
+fi
+
+if ! docker compose version &>/dev/null; then
+    echo "[autoinstall] Installing docker compose plugin..."
+    apt-get install -y docker-compose-plugin
+fi
+
+# Wait up to 30 s for Docker daemon
+timeout 30 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done' \
+    || { echo "[autoinstall] Docker daemon did not start"; exit 1; }
+
+# ── NVIDIA Container Toolkit (GPU instances only) ─────────────────────────────
+HAS_GPU=false
+if command -v nvidia-smi &>/dev/null \
+    && nvidia-smi --list-gpus >/dev/null 2>&1 \
+    && [ "$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
+    HAS_GPU=true
+fi
+
+if $HAS_GPU; then
+    echo "[autoinstall] GPU detected — installing NVIDIA Container Toolkit..."
+    distribution=$(. /etc/os-release && echo "${ID}${VERSION_ID}")
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+        | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+    curl -fsSL "https://nvidia.github.io/libnvidia-container/${distribution}/libnvidia-container.list" \
+        | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+        | tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    apt-get update -q
+    apt-get install -y nvidia-container-toolkit
+    nvidia-ctk runtime configure --runtime=docker
+    systemctl restart docker
+    timeout 30 bash -c 'until docker info &>/dev/null 2>&1; do sleep 1; done'
+fi
+
+# ── .env warning ──────────────────────────────────────────────────────────────
+if [ ! -f "${REPO_DIR}/.env" ]; then
+    echo "[autoinstall] WARNING: .env not found. Copy .env.example to .env and fill in Slack webhooks."
+fi
+
+# ── Build and start container ─────────────────────────────────────────────────
+cd "$REPO_DIR"
+if $HAS_GPU; then
+    docker compose build
+    docker compose up -d
+else
+    docker compose -f docker-compose.yml -f docker-compose.cpu.yml build
+    docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
+fi
+
+echo "[autoinstall] Container started:"
+docker ps --filter "name=gpumon" --format "  {{.Names}}  {{.Status}}"
+
+# ── halt_it.sh on host crontab ────────────────────────────────────────────────
+cp "${REPO_DIR}/halt_it.sh" "${HALT_HOST}"
+chmod +x "${HALT_HOST}"
+
+CRON_JOB="*/10 * * * * ${HALT_HOST} >> /var/log/halt_it.log 2>&1"
+if ! crontab -l 2>/dev/null | grep -q "halt_it.sh"; then
+    ( crontab -l 2>/dev/null; echo "$CRON_JOB" ) | crontab -
+    echo "[autoinstall] halt_it.sh cron job installed"
+else
+    echo "[autoinstall] halt_it.sh already in crontab"
+fi
+
+# ── Auto-update script ────────────────────────────────────────────────────────
+cat > "${UPDATE_SCRIPT}" << UPDATESCRIPT
+#!/bin/bash
+set -euo pipefail
+REPO_DIR="${REPO_DIR}"
+
+BEFORE=\$(git -C "\$REPO_DIR" rev-parse HEAD)
+git -C "\$REPO_DIR" pull --force --quiet
+AFTER=\$(git -C "\$REPO_DIR" rev-parse HEAD)
+
+if [ "\$BEFORE" = "\$AFTER" ]; then
+    echo "[\$(date)] gpumon-update: no changes"
+    exit 0
+fi
+
+echo "[\$(date)] gpumon-update: \$BEFORE -> \$AFTER — rebuilding container"
+cp "\${REPO_DIR}/halt_it.sh" "${HALT_HOST}"
+chmod +x "${HALT_HOST}"
+
+cd "\$REPO_DIR"
+if command -v nvidia-smi &>/dev/null \\
+        && nvidia-smi --list-gpus >/dev/null 2>&1 \\
+        && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
+    docker compose up -d --build
+else
+    docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d --build
+fi
+echo "[\$(date)] gpumon-update: done"
+UPDATESCRIPT
+chmod +x "${UPDATE_SCRIPT}"
+
+# ── Systemd timer for hourly auto-updates ─────────────────────────────────────
+cat > /etc/systemd/system/gpumon-update.service << 'EOF'
+[Unit]
+Description=gpumon auto-update
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/gpumon-update.sh
+StandardOutput=journal
+StandardError=journal
+EOF
+
+cat > /etc/systemd/system/gpumon-update.timer << 'EOF'
+[Unit]
+Description=gpumon auto-update timer
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now gpumon-update.timer
+
+echo "[autoinstall] Auto-update timer enabled (fires 5 min post-boot, then every 1 h)"
+echo "[autoinstall] Installation complete."
+touch "$SENTINEL"

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -46,8 +46,11 @@ if [ "\$BEFORE" = "\$AFTER" ]; then
 fi
 
 echo "[\$(date)] gpumon-update: \$BEFORE -> \$AFTER — rebuilding container"
-cp "\${REPO_DIR}/halt_it.sh" "${HALT_HOST}"
-chmod +x "${HALT_HOST}"
+
+# Re-run autoinstall.sh so service-file regeneration (gpumon-boot.sh, gpumon-update.sh,
+# halt_it.sh, systemd units) picks up any changes in the new commit.  The sentinel at
+# /var/log/gpumon.finished short-circuits the heavy apt/docker install part.
+bash "\${REPO_DIR}/autoinstall.sh"
 
 cd "\$REPO_DIR"
 if command -v nvidia-smi &>/dev/null \\

--- a/autoinstall.sh
+++ b/autoinstall.sh
@@ -86,6 +86,20 @@ pkill -f "python3 /root/gpumon/gpumon.py" 2>/dev/null || true
 pkill -f "python3 /root/gpumon/cpumon.py" 2>/dev/null || true
 pkill -f "python3 /root/gpumon/hostmon.py" 2>/dev/null || true
 
+# Ensure .env exists so docker compose can satisfy env_file: .env.
+# Idempotent — skipped when a .env is already present so manual edits survive.
+# Needed at boot because the AMI's source repo is gitignore-stripped (.env is
+# never tracked), so a fresh clone or new SPOT launch arrives without one.
+if [ ! -f "\$REPO_DIR/.env" ]; then
+    echo "[\$(date)] gpumon-boot: .env missing — writing defaults"
+    cat > "\$REPO_DIR/.env" <<'ENVEOF'
+GPUMON_SLACK_SECRET_ID=IT/SLACK_BOT_TOKEN
+GPUMON_SLACK_SECRET_REGION=eu-west-1
+GPUMON_SECRET_ID=AB/InstanceRole
+GPUMON_SECRET_REGION=eu-west-1
+ENVEOF
+fi
+
 if command -v nvidia-smi &>/dev/null \\
         && nvidia-smi --list-gpus >/dev/null 2>&1 \\
         && [ "\$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then

--- a/cpumon.py
+++ b/cpumon.py
@@ -118,6 +118,7 @@ def main() -> None:
     restart_backoff   = cfg["restart_backoff"]
     cpu_threshold     = cfg["cpu_threshold"]
     network_threshold = cfg["network_threshold"]
+    shutdown_eta      = cfg["shutdown_eta"]
 
     shutdown_cooldown_hours = float(os.getenv("SHUTDOWN_ALERT_COOLDOWN_HOURS", "4"))
 
@@ -144,6 +145,7 @@ def main() -> None:
                     restart_backoff   = cfg["restart_backoff"]
                     cpu_threshold     = cfg["cpu_threshold"]
                     network_threshold = cfg["network_threshold"]
+                    shutdown_eta      = cfg["shutdown_eta"]
             except Exception as exc:
                 print(f"policy refresh error: {exc}")
 
@@ -182,7 +184,7 @@ def main() -> None:
                         dm_client.send_dm(
                             emp_name,
                             f":alarm_clock: Your instance *{instance_name}* appears idle "
-                            f"and is scheduled to shut down in ~3 hours.",
+                            f"and is scheduled to shut down in {shutdown_eta}.",
                         )
             else:
                 if alarm_pilot_light == 1:

--- a/cpumon.py
+++ b/cpumon.py
@@ -168,8 +168,10 @@ def main() -> None:
 
         # ── Network ──────────────────────────────────────────────────────────
         network = get_network_stats(cw, instance_id, network)
-        if network_tripped == 0 and network <= network_threshold:
+        if network <= network_threshold:
             network_tripped = 1
+        else:
+            network_tripped = 0
 
         # ── Alarm pilot light ────────────────────────────────────────────────
         if seconds >= restart_backoff:

--- a/cpumon.py
+++ b/cpumon.py
@@ -21,9 +21,7 @@ from mon_utils import (
     get_network_stats,
     get_per_core_cpu_utilization,
     get_policy_config,
-    resolve_webhooks,
     seconds_elapsed,
-    send_slack,
     try_record_alert,
 )
 
@@ -123,8 +121,6 @@ def main() -> None:
 
     shutdown_cooldown_hours = float(os.getenv("SHUTDOWN_ALERT_COOLDOWN_HOURS", "4"))
 
-    team_webhook, _ = resolve_webhooks(team)
-
     # Slack DM client — None if secret not configured or unreachable
     slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "AB/SlackBotToken")
     slack_secret_region = os.getenv("GPUMON_SLACK_SECRET_REGION", os.getenv("GPUMON_SECRET_REGION", "eu-west-1"))
@@ -180,12 +176,6 @@ def main() -> None:
             if not cpu_util_tripped and network <= network_threshold:
                 if alarm_pilot_light == 0:
                     alarm_pilot_light = 1
-                    # Team channel notification (always)
-                    send_slack(team_webhook,
-                               f"[ {current_time} ] INSTANCE: {instance_name} - {instance_id} ({hostname}) "
-                               f"CPU and NETWORK seems idle, TURNED ALARM PILOT LIGHT to: ON, "
-                               f"instance is expected to stop in: 3 hours")
-                    # Personal DM to employee (rate-limited, not on SPOT)
                     if dm_client and try_record_alert("shutdown_alert", shutdown_cooldown_hours):
                         dm_client.send_dm(
                             emp_name,
@@ -195,10 +185,6 @@ def main() -> None:
             else:
                 if alarm_pilot_light == 1:
                     alarm_pilot_light = 0
-                    # Team channel only — no DM to employee for OFF transition
-                    send_slack(team_webhook,
-                               f"[ {current_time} ] INSTANCE: {instance_name} - {instance_id} ({hostname}) "
-                               f"CPU and NETWORK over minimum threshold, TURNED ALARM PILOT LIGHT to: OFF")
         else:
             alarm_pilot_light = 0
 

--- a/cpumon.py
+++ b/cpumon.py
@@ -1,417 +1,206 @@
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with the License.
-# A copy of the License is located at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#  
-#  or in the "license" file accompanying this file. This file is distributed 
-#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-#  express or implied. See the License for the specific language governing 
-#  permissions and limitations under the License.
-###########
-# Some changes to script have been made by Paul Seifer to adapt to python3.9, such as conversion of values to utf-8 strings.
-try:
-    from urllib.request import Request, urlopen
-except ImportError:
-    from urllib2 import Request, urlopen
-import psutil
-import boto3
-from datetime import datetime, timedelta
-from time import sleep
-import time
-import requests
+# Licensed under the Apache License, Version 2.0
+# Adapted for Python 3 and extended by Paul Seifer, Autobrains LTD
+
+from __future__ import annotations
+
 import os
-import subprocess
+from datetime import datetime
+from time import sleep
+
+import boto3
+import psutil
+
+from mon_utils import (
+    build_slack_dm_client,
+    calculate_average_core_utilization,
+    cleanup_old_logs,
+    create_tag,
+    ensure_halt_it_crontab,
+    fetch_instance_metadata,
+    get_instance_tags,
+    get_network_stats,
+    get_per_core_cpu_utilization,
+    get_policy_config,
+    record_alert_sent,
+    resolve_webhooks,
+    seconds_elapsed,
+    send_slack,
+    should_send_alert,
+)
+
+NAMESPACE = "CPU-metrics"
+TMP_FILE_PREFIX = "/tmp/CPUMON_LOGS_"
+SLEEP_INTERVAL = 10
+STORE_RESO = 60
+CACHE_DURATION = 300  # seconds of CPU history to keep
 
 
-# Constants
-CACHE_DURATION = 300  # 5 minutes in seconds
-THRESHOLD_PERCENTAGE = 10  # Threshold for average core utilization
-
-# Variables
-core_utilization_cache = [[] for _ in range(psutil.cpu_count())]  # List to store utilization data for each core
-cpu_util_tripped = 0
-
-def check_root_crontab(search_string):
-    try:
-        # Run the command to list root's crontab
-        result = subprocess.run(['sudo', 'crontab', '-l'], capture_output=True, text=True, check=True)
-
-        # Check if the search string is in the output
-        if search_string in result.stdout:
-            return True
-        else:
-            return False
-    except subprocess.CalledProcessError as e:
-        print(f"An error occurred: {e}")
-        return False
-    except PermissionError:
-        print("Permission denied. Make sure you have sudo privileges.")
-        return False
-def add_to_root_crontab(new_cron_job):
-    try:
-        # Get the current crontab content
-        current_crontab = subprocess.run(['sudo', 'crontab', '-l'], capture_output=True, text=True, check=True)
-
-        # Append the new job to the existing content
-        new_crontab = current_crontab.stdout + new_cron_job + "\n"
-
-        # Write the new crontab content
-        process = subprocess.Popen(['sudo', 'crontab', '-'], stdin=subprocess.PIPE, text=True)
-        process.communicate(input=new_crontab)
-
-        if process.returncode == 0:
-            print("New cron job added successfully.")
-            return True
-        else:
-            print("Failed to add new cron job.")
-            return False
-    except subprocess.CalledProcessError as e:
-        print(f"An error occurred: {e}")
-        return False
-    except PermissionError:
-        print("Permission denied. Make sure you have sudo privileges.")
-        return False
-def seconds_elapsed():
-    return time.time() - psutil.boot_time()
-
-def get_per_core_cpu_utilization():
-    return psutil.cpu_percent(interval=1, percpu=True)
-
-def calculate_average_core_utilization():
-    return [sum(core_data) / len(core_data) if core_data else 0 for core_data in core_utilization_cache]
-
-### CHOOSE REGION ####
-EC2_REGION = 'eu-west-1'
-
-###CHOOSE NAMESPACE PARMETERS HERE###
-my_NameSpace = 'CPU-metrics' 
-
-sleep_interval = 10
-
-### CHOOSE STORAGE RESOLUTION (BETWEEN 1-60) ####
-store_reso = 60
-
-#Instance information
-BASE_URL = 'http://169.254.169.254/latest/meta-data/'
-req = Request('http://169.254.169.254/latest/api/token',None,{'X-aws-ec2-metadata-token-ttl-seconds' : '21600'},method='PUT')
-TOKEN = urlopen(req).read().decode("utf-8")
-req = Request(BASE_URL + 'instance-id', None,{'X-aws-ec2-metadata-token' : TOKEN },method='GET')
-INSTANCE_ID = urlopen(req).read().decode("utf-8") 
-req = Request(BASE_URL + 'ami-id', None,{'X-aws-ec2-metadata-token' : TOKEN },method='GET')
-IMAGE_ID = urlopen(req).read().decode("utf-8")
-req = Request(BASE_URL + 'instance-type', None,{'X-aws-ec2-metadata-token' : TOKEN },method='GET')
-INSTANCE_TYPE = urlopen(req).read().decode("utf-8") 
-req = Request(BASE_URL + 'placement/availability-zone', None,{'X-aws-ec2-metadata-token' : TOKEN },method='GET')
-INSTANCE_AZ = urlopen(req).read().decode("utf-8")  
-req = Request(BASE_URL + 'hostname', None,{'X-aws-ec2-metadata-token' : TOKEN },method='GET')
-HOSTNAME = urlopen(req).read().decode("utf-8")  
-TIMESTAMP = datetime.now().strftime('%Y-%m-%dT%H')
-TMP_FILE = '/tmp/CPUMON_LOGS_'
-TMP_FILE_SAVED = TMP_FILE + TIMESTAMP
-# Create EC2 client to get tags
-ec2 = boto3.client('ec2', region_name=EC2_REGION)
-# Create CloudWatch client
-cloudwatch = boto3.client('cloudwatch', region_name=EC2_REGION)
-
-def get_network_stats(instance_id,network):
-    # Set the end time to the current time
-    end = datetime.utcnow()
-    # Set the start time to 5 minutes ago
-    start = end - timedelta(minutes=5)
-    # Format the time strings
-    start_str = start.strftime("%Y-%m-%dT%H:%M:%SZ")
-    end_str = end.strftime("%Y-%m-%dT%H:%M:%SZ")
-    #print("From:",start_str,"Till:",end_str,"instance:",instance_id)
-    data_in = cloudwatch.get_metric_statistics(
-        Period=60,
-        StartTime=start_str,
-        EndTime=end_str,
-        MetricName="NetworkPacketsIn",
-        Namespace="AWS/EC2",
-        Statistics=["Maximum"],
-        Unit="Count",
-        Dimensions=[{'Name': 'InstanceId', 'Value': str(instance_id)}]
+def _log_results(
+    log_file: str,
+    cw_client,
+    instance_id: str,
+    image_id: str,
+    instance_type: str,
+    team: str,
+    emp_name: str,
+    alarm_pilot_light: int,
+    cpu_util_tripped: bool,
+    seconds: int,
+    current_time: datetime,
+    per_core_utilization: list[float],
+    network: float,
+    network_tripped: int,
+) -> None:
+    line = (
+        f"[ {current_time} ] "
+        f"tag:{team},"
+        f"Employee:{emp_name},"
+        f"Alarm_Pilot_value:{alarm_pilot_light},"
+        f"CPU_Util_Tripped:{cpu_util_tripped},"
+        f"Seconds Elapsed since reboot:{seconds},"
+        f"Per-Core CPU Util:{per_core_utilization},"
+        f"NetworkStats:{network},"
+        f"Network_Tripped:{network_tripped}\n"
     )
-    #print("data_in:",data_in)
-    data_out = cloudwatch.get_metric_statistics(
-        Period=60,
-        StartTime=start_str,
-        EndTime=end_str,
-        MetricName="NetworkPacketsOut",
-        Namespace="AWS/EC2",
-        Statistics=["Maximum"],
-        Unit="Count",
-        Dimensions=[{'Name': 'InstanceId', 'Value': str(instance_id)}]
-    )
-    datapoints_in = data_in.get("Datapoints", [])
-    #print("datapoints_in:",datapoints_in)
-    datapoints_out = data_out.get("Datapoints",[])
-    first_datapoint_in = 1 #we dont want to switch off instance if we werent able to bring metrics in
-    first_datapoint_out = 1
-    if datapoints_in:
-        # Access the first data point (assuming there is at least one)
-        first_datapoint_in = datapoints_in[0]["Maximum"]
-        #print(f"packetsin:{round(first_datapoint_in)}")
-    else:
-        first_datapoint_in = network / 2
-        print("No data points found.")
-    if datapoints_out:
-        # Access the first data point (assuming there is at least one)
-        first_datapoint_out = datapoints_out[0]["Maximum"]
-        #print(f"packetsout:{round(first_datapoint_out)}")
-    else:
-        first_datapoint_in = network / 2
-        print("No data points found.")
-    network_sum = round(first_datapoint_in) + round(first_datapoint_out)
-    return network_sum
-
-# Flag to push to CloudWatch
-PUSH_TO_CW = True
-def get_instance_tags(instance_id):
     try:
-        response = ec2.describe_tags(
-            Filters=[
-                {
-                    'Name': 'resource-id',
-                    'Values': [instance_id]
-                }
-            ]
-        )
-        tags = {tag['Key']: tag['Value'] for tag in response['Tags']}
-        return tags
-    except ClientError:
-        print(f"Couldn't get tags for instance {instance_id}")
-        raise
-def send_slack(webhook_url,message):
-    message=f"{message}"   
-    payload = {
-        "text": message
-    }
+        with open(log_file, "a") as fh:
+            fh.write(line)
+    except OSError as exc:
+        print(f"log write error: {exc}")
 
-    response = requests.post(webhook_url, json=payload)
-
-    if response.status_code == 200:
-        print("Message sent to Slack successfully.")
-    else:
-        print(f"Failed to send message to Slack. Status code: {response.status_code}")
-def create_tag(instance_id, tag_name, default_value):
-    """
-    Ensures that a particular tag is present in the instance tags.
-    If the tag is not present, it adds the tag with the specified default value.
-
-    :param instance_id: The ID of the instance.
-    :param tag_name: The tag name to check for.
-    :param default_value: The default value to set if the tag is not found.
-    :return: None
-    """
-    ec2.create_tags(
-        Resources=[instance_id],
-        Tags=[{'Key': tag_name, 'Value': default_value}]
-        )
-    print(f"Tag '{tag_name}' with value '{default_value}' added to instance {instance_id}.")
-
-def logResults(team, emp_name, alarm_pilot_light, cpu_util_tripped, seconds, current_time, per_core_utilization, network, network_tripped):
+    dims = [
+        {"Name": "InstanceId",    "Value": instance_id},
+        {"Name": "ImageId",       "Value": image_id},
+        {"Name": "InstanceType",  "Value": instance_type},
+        {"Name": "InstanceTag",   "Value": team},
+        {"Name": "EmployeeTag",   "Value": emp_name},
+    ]
     try:
-        gpu_logs = open(TMP_FILE_SAVED, 'a+')
-        writeString = '[ ' + str(current_time) + ' ] ' + 'tag:' + team + ',' + 'Employee:' + emp_name + ',' + 'Alarm_Pilot_value:' + str(alarm_pilot_light) + ',' + 'CPU_Util_Tripped:' + str(cpu_util_tripped) + ',' + 'Seconds Elapsed since reboot:' + str(seconds) + ',' + 'Per-Core CPU Util:' + str(per_core_utilization) + ',' + 'NetworkStats:' + str(network) + ',' + 'Network_Tripped:' + str(network_tripped) + '\n'
-        gpu_logs.write(writeString)
-    except:
-        print("Error writing to file ", gpu_logs)
-    finally:
-        gpu_logs.close()
-    if (PUSH_TO_CW):
-        MY_DIMENSIONS=[
-                    {
-                        'Name': 'InstanceId',
-                        'Value': INSTANCE_ID
-                    },
-                    {
-                        'Name': 'ImageId',
-                        'Value': IMAGE_ID
-                    },
-                    {
-                        'Name': 'InstanceType',
-                        'Value': INSTANCE_TYPE
-                    },
-                    {
-                        'Name': 'InstanceTag',
-                        'Value': str(team)
-                    },
-                    {
-                        'Name': 'EmployeeTag',
-                        'Value': str(emp_name)
-                    }
-
-                ]
-        cloudwatch.put_metric_data(
+        cw_client.put_metric_data(
+            Namespace=NAMESPACE,
             MetricData=[
-                {
-                    'MetricName': 'Alarm Pilot Light (1/0)',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'None',
-                    'StorageResolution': store_reso,
-                    'Value': float(alarm_pilot_light)
-                },
-                {
-                    'MetricName': 'CPU Utilization Low Tripped',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'None',
-                    'StorageResolution': store_reso,
-                    'Value': float(cpu_util_tripped)
-                },
-                {
-                    'MetricName': 'Network Tripped',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'None',
-                    'StorageResolution': store_reso,
-                    'Value': float(network_tripped)
-                }
-
-
-        ],
-            Namespace=my_NameSpace
+                {"MetricName": "Alarm Pilot Light (1/0)",     "Dimensions": dims, "Unit": "None", "StorageResolution": STORE_RESO, "Value": float(alarm_pilot_light)},
+                {"MetricName": "CPU Utilization Low Tripped", "Dimensions": dims, "Unit": "None", "StorageResolution": STORE_RESO, "Value": float(cpu_util_tripped)},
+                {"MetricName": "Network Tripped",             "Dimensions": dims, "Unit": "None", "StorageResolution": STORE_RESO, "Value": float(network_tripped)},
+            ],
         )
-    
+    except Exception as exc:
+        print(f"CloudWatch put_metric_data error: {exc}")
 
-def main():
-    result = check_root_crontab("halt_it.sh")
-    if result:
-       print("halt_it.sh presence in crontab detected, continue")
-    else:
-       print("updating crontab with new halt_it.sh call")
-       new_job = "*/10 * * * * bash /root/gpumon/halt_it.sh | tee -a /tmp/halt_it_log.txt"
-       add_to_root_crontab(new_job)
 
-    global core_utilization_cache
+def main() -> None:
+    cleanup_old_logs(TMP_FILE_PREFIX, max_age_hours=48)
+    ensure_halt_it_crontab(
+        "*/10 * * * * bash /root/gpumon/halt_it.sh | tee -a /tmp/halt_it_log.txt"
+    )
+
+    meta = fetch_instance_metadata()
+    region        = meta["region"]
+    instance_id   = meta["instance_id"]
+    image_id      = meta["image_id"]
+    instance_type = meta["instance_type"]
+    hostname      = meta["hostname"]
+
+    ec2 = boto3.client("ec2",        region_name=region)
+    cw  = boto3.client("cloudwatch", region_name=region)
+
+    tags = get_instance_tags(ec2, instance_id)
+    instance_name = tags.get("Name", "NO_NAME_TAG")
+    team          = tags.get("Team", "NO_TAG")
+    emp_name      = tags.get("Employee", "NO_TAG")
+    policy        = tags.get("GPUMON_POLICY")
+    if policy is None:
+        policy = "STANDARD"
+        create_tag(ec2, instance_id, "GPUMON_POLICY", policy)
+
+    # SPOT instances: never DM the employee
+    page_employee = (
+        policy != "SPOT"
+        and tags.get("PAGE_EMPLOYEE", "True").lower() != "false"
+    )
+
+    cfg = get_policy_config(policy)
+    restart_backoff   = cfg["restart_backoff"]
+    cpu_threshold     = cfg["cpu_threshold"]
+    network_threshold = cfg["network_threshold"]
+
+    shutdown_cooldown_hours = float(os.getenv("SHUTDOWN_ALERT_COOLDOWN_HOURS", "4"))
+
+    team_webhook, _ = resolve_webhooks(team)
+
+    # Slack DM client — None if secret not configured or unreachable
+    slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "AB/SlackBotToken")
+    slack_secret_region = os.getenv("GPUMON_SLACK_SECRET_REGION", os.getenv("GPUMON_SECRET_REGION", "eu-west-1"))
+    dm_client = build_slack_dm_client(slack_secret_id, slack_secret_region) if page_employee else None
+
+    core_cache: list[list[float]] = [[] for _ in range(psutil.cpu_count())]
     alarm_pilot_light = 0
-    network_tripped = 0
-    network = 99
-    cpu_util_tripped = False
-    policy = 'STANDARD'
-    tags = get_instance_tags(INSTANCE_ID)
-    if 'Name' in tags:
-        instance_name = str(tags['Name'])
-    else:
-        instance_name = "NO_NAME_TAG"
-    if 'Team' in tags:
-        team = str(tags['Team'])
-    else:
-        team = "NO_TAG"
-    if 'Employee' in tags:
-        emp_name = str(tags['Employee'])
-    else:
-        emp_name = "NO_TAG"
-    if 'GPUMON_POLICY' in tags:
-        policy = str(tags['GPUMON_POLICY'])
-    else:
-        create_tag(INSTANCE_ID,'GPUMON_POLICY',policy)
+    network_tripped   = 0
+    network: float    = 99.0
 
-    if policy == 'RELAXED':
-        print('POLICY TAG detected:',{policy})
-        RESTART_BACKOFF = 7200 # will wait 2 hours to even start the evaluation
-        THRESHOLD_PERCENTAGE = 5 #over 5 percent CPU utilization will stop the shutdown sequence
-        GPU_THRESHOLD = 10 # Over 10 percent GPU average utilization will stop the shutdown sequence
-        NETWORK_THRESHOLD = 10000 # Over 10K packets in/out combined will stop the shutdown sequence
-    elif policy == "SEVERE":
-        print('POLICY TAG detected:',{policy}) 
-        RESTART_BACKOFF = 0 # will not wait and will start evaluation immediately upon boot
-        THRESHOLD_PERCENTAGE = 20 #over 20% CPU utilization will stop the shutdown sequence
-        GPU_THRESHOLD = 2
-        NETWORK_THRESHOLD = 15000 #over 15K packets in/out combined will stop the shutdown sequence
-    elif policy == "SPOT": #this is the most aggressive shutdown, 15 min of inactivity
-        print('POLICY TAG detected:',{policy})
-        RESTART_BACKOFF = 0 #0 seconds backoff - the alert pilot switches to 1 right away if idle
-        THRESHOLD_PERCENTAGE = 20 # under 20% is considered idle
-        GPU_THRESHOLD = 10 # Over 10 percent GPU average utilization will stop the shutdown sequence
-        NETWORK_THRESHOLD = 30000 # Over 30K packets in/out combined will stop the shutdown sequence
-    elif policy == "SUSPEND": #this should keep it running even if no activity is detected
-        print('POLICY TAG detected:',{policy})
-        RESTART_BACKOFF = 864000 #10 days backoff then if the box is really quiet it can die
-        THRESHOLD_PERCENTAGE = 10 
-        GPU_THRESHOLD = 10
-        NETWORK_THRESHOLD = 15000
-    else:   
-        print('POLICY TAG detected:',{policy})
-        RESTART_BACKOFF = 3600 #This is STANDARD policy tag - 1 hour backoff, 10% cPu threshold 10% GPU and 15K network
-        THRESHOLD_PERCENTAGE = 10
-        GPU_THRESHOLD = 10
-        NETWORK_THRESHOLD = 15000
-        
-    #print("team_var:",team_var)
-    try:
-        team_webhook = os.getenv(team_var)
-    except:
+    while True:
+        current_time = datetime.now()
+        log_file = TMP_FILE_PREFIX + current_time.strftime("%Y-%m-%dT%H")
+        cpu_util_tripped = False
+
+        # ── CPU utilization cache ────────────────────────────────────────────
         try:
-            send_slack(debug_webhook,f"achtung, could not resolve team_webhook_url on {instance_name} {INSTANCE_ID} - {team_var}")
-            team_webhook = debug_webhook
-        except:
-            print(f"AAAARGH! DEBUG WEBHOOK is None:${DEBUG_WEBHOOK_URL} or cannot send data out, debug")
-    try:
-        while True:
-            cpu_util_tripped = False
-            try:
-                # Get per-core CPU utilization
-                per_core_utilization = get_per_core_cpu_utilization()
+            per_core = get_per_core_cpu_utilization()
+            for i, v in enumerate(per_core):
+                core_cache[i].append(v)
+            core_cache = [d[-int(CACHE_DURATION / SLEEP_INTERVAL):] for d in core_cache]
+            avg_cores = calculate_average_core_utilization(core_cache)
+            if any(u > cpu_threshold for u in avg_cores):
+                cpu_util_tripped = True
+        except Exception as exc:
+            print(f"CPU utilization error: {exc}")
+            per_core = []
 
-                # Cache utilization data for each core
-                for i, core_util in enumerate(per_core_utilization):
-                    core_utilization_cache[i].append(core_util)
+        seconds = round(seconds_elapsed())
 
-                # Remove outdated data from the cache
-                current_time = datetime.now()
-                core_utilization_cache = [core_data[-int(CACHE_DURATION / 1):] for core_data in core_utilization_cache]
-                # Calculate average core utilization
-                average_core_utilization = calculate_average_core_utilization()
-                #print(average_core_utilization)
-                # Check if any core exceeds the threshold
-                if any(utilization > THRESHOLD_PERCENTAGE for utilization in average_core_utilization):
-                    cpu_util_tripped = True
-                    #print("Threshold exceeded. Changing variable to True.")
-            except:
-                    print('Could not get cpu core utilization statistics, debug')
+        # ── Network ──────────────────────────────────────────────────────────
+        network = get_network_stats(cw, instance_id, network)
+        if network_tripped == 0 and network <= network_threshold:
+            network_tripped = 1
 
-
-            PUSH_TO_CW = True
-            
-            seconds = round(float(seconds_elapsed()))
- 
-            # calculate combined network in and out last 5 min
-            network = get_network_stats(instance_id=INSTANCE_ID,network=network)
-            if network_tripped == 0 and network <= NETWORK_THRESHOLD:
-                network_tripped = 1
-            #print(f"name_tag:{instance_name} network:{network}")
-            if seconds >= RESTART_BACKOFF:
-                if cpu_util_tripped == False and network <= NETWORK_THRESHOLD:    
-            #cpu util tripped == True means that there was higher than threshold cpu core activity and we cant stop the instance because of it
-                    if alarm_pilot_light == 0:
-                        #print(f'CPU or GPU below {THRESHOLD_PERCENTAGE}% threshold, turning pilot light ON')
-                        alarm_pilot_light = 1
-                        mmessage=f"[ {current_time} ] INSTANCE: {instance_name} - {INSTANCE_ID} ({HOSTNAME}) CPU and NETWORK seems idle, TURNED ALARM PILOT LIGHT to: ON, instance is expected to stop in: 3 hours"
-                        try:
-                            send_slack(team_webhook, mmessage)
-                        except:
-                            print(f"Could not send slack to webhook:{team_webhook}")
-                else:
-                    if alarm_pilot_light == 1:
-                        alarm_pilot_light = 0
-                        mmessage=f"[ {current_time} ] INSTANCE: {instance_name} - {INSTANCE_ID} ({HOSTNAME}) CPU and NETWORK over minimum threshold, TURNED ALARM PILOT LIGHT to: OFF"
-                        try:
-                            send_slack(team_webhook, mmessage)
-                        except:
-                            print(f"Could not send slack to webhook:{team_webhook}")
-                    #print(f'CPU or GPU above {THRESHOLD_PERCENTAGE}% threshold, turning pilot light OFF')
+        # ── Alarm pilot light ────────────────────────────────────────────────
+        if seconds >= restart_backoff:
+            if not cpu_util_tripped and network <= network_threshold:
+                if alarm_pilot_light == 0:
+                    alarm_pilot_light = 1
+                    # Team channel notification (always)
+                    send_slack(team_webhook,
+                               f"[ {current_time} ] INSTANCE: {instance_name} - {instance_id} ({hostname}) "
+                               f"CPU and NETWORK seems idle, TURNED ALARM PILOT LIGHT to: ON, "
+                               f"instance is expected to stop in: 3 hours")
+                    # Personal DM to employee (rate-limited, not on SPOT)
+                    if dm_client and should_send_alert("shutdown_alert", shutdown_cooldown_hours):
+                        dm_client.send_dm(
+                            emp_name,
+                            f":alarm_clock: Your instance *{instance_name}* appears idle "
+                            f"and is scheduled to shut down in ~3 hours.",
+                        )
+                        record_alert_sent("shutdown_alert")
             else:
-                alarm_pilot_light = 0
-            # Log the results
-            try:
-                logResults(team, emp_name, alarm_pilot_light, cpu_util_tripped, seconds,current_time,per_core_utilization,network,network_tripped)
-            except:
-                print("had an issue with writing to disk probably, it doesnt matter as long as cloudwatch is updated")
-            sleep(sleep_interval)
-    finally:
-        pass
-if __name__=='__main__':
+                if alarm_pilot_light == 1:
+                    alarm_pilot_light = 0
+                    # Team channel only — no DM to employee for OFF transition
+                    send_slack(team_webhook,
+                               f"[ {current_time} ] INSTANCE: {instance_name} - {instance_id} ({hostname}) "
+                               f"CPU and NETWORK over minimum threshold, TURNED ALARM PILOT LIGHT to: OFF")
+        else:
+            alarm_pilot_light = 0
+
+        # ── Log & push ───────────────────────────────────────────────────────
+        _log_results(
+            log_file, cw, instance_id, image_id, instance_type,
+            team, emp_name, alarm_pilot_light, cpu_util_tripped,
+            seconds, current_time, per_core, network, network_tripped,
+        )
+
+        sleep(SLEEP_INTERVAL)
+
+
+if __name__ == "__main__":
     main()

--- a/cpumon.py
+++ b/cpumon.py
@@ -32,6 +32,7 @@ TMP_FILE_PREFIX = "/tmp/CPUMON_LOGS_"
 SLEEP_INTERVAL = 10
 STORE_RESO = 60
 CACHE_DURATION = 300  # seconds of CPU history to keep
+POLICY_REFRESH_LOOPS = 60   # re-read GPUMON_POLICY tag every ~10 min
 
 
 def _log_results(
@@ -134,7 +135,22 @@ def main() -> None:
     network_tripped   = 0
     network: float    = 99.0
 
+    loop_count = 0
     while True:
+        loop_count += 1
+        if loop_count % POLICY_REFRESH_LOOPS == 0:
+            try:
+                fresh_tags = get_instance_tags(ec2, instance_id)
+                new_policy = fresh_tags.get("GPUMON_POLICY", policy)
+                if new_policy != policy:
+                    policy = new_policy
+                    cfg = get_policy_config(policy)
+                    restart_backoff   = cfg["restart_backoff"]
+                    cpu_threshold     = cfg["cpu_threshold"]
+                    network_threshold = cfg["network_threshold"]
+            except Exception as exc:
+                print(f"policy refresh error: {exc}")
+
         current_time = datetime.now()
         log_file = TMP_FILE_PREFIX + current_time.strftime("%Y-%m-%dT%H")
         cpu_util_tripped = False

--- a/cpumon.py
+++ b/cpumon.py
@@ -16,17 +16,15 @@ from mon_utils import (
     calculate_average_core_utilization,
     cleanup_old_logs,
     create_tag,
-    ensure_halt_it_crontab,
     fetch_instance_metadata,
     get_instance_tags,
     get_network_stats,
     get_per_core_cpu_utilization,
     get_policy_config,
-    record_alert_sent,
     resolve_webhooks,
     seconds_elapsed,
     send_slack,
-    should_send_alert,
+    try_record_alert,
 )
 
 NAMESPACE = "CPU-metrics"
@@ -91,9 +89,6 @@ def _log_results(
 
 def main() -> None:
     cleanup_old_logs(TMP_FILE_PREFIX, max_age_hours=48)
-    ensure_halt_it_crontab(
-        "*/10 * * * * bash /root/gpumon/halt_it.sh | tee -a /tmp/halt_it_log.txt"
-    )
 
     meta = fetch_instance_metadata()
     region        = meta["region"]
@@ -175,13 +170,12 @@ def main() -> None:
                                f"CPU and NETWORK seems idle, TURNED ALARM PILOT LIGHT to: ON, "
                                f"instance is expected to stop in: 3 hours")
                     # Personal DM to employee (rate-limited, not on SPOT)
-                    if dm_client and should_send_alert("shutdown_alert", shutdown_cooldown_hours):
+                    if dm_client and try_record_alert("shutdown_alert", shutdown_cooldown_hours):
                         dm_client.send_dm(
                             emp_name,
                             f":alarm_clock: Your instance *{instance_name}* appears idle "
                             f"and is scheduled to shut down in ~3 hours.",
                         )
-                        record_alert_sent("shutdown_alert")
             else:
                 if alarm_pilot_light == 1:
                     alarm_pilot_light = 0

--- a/cpumon.py
+++ b/cpumon.py
@@ -108,9 +108,9 @@ def main() -> None:
         policy = "STANDARD"
         create_tag(ec2, instance_id, "GPUMON_POLICY", policy)
 
-    # SPOT instances: never DM the employee
+    # SPOT/SEVERE: no idle shutdown DM (disk/memory alerts handled by hostmon.py)
     page_employee = (
-        policy != "SPOT"
+        policy not in ("SPOT", "SEVERE")
         and tags.get("PAGE_EMPLOYEE", "True").lower() != "false"
     )
 

--- a/cpumon.py
+++ b/cpumon.py
@@ -122,7 +122,7 @@ def main() -> None:
     shutdown_cooldown_hours = float(os.getenv("SHUTDOWN_ALERT_COOLDOWN_HOURS", "4"))
 
     # Slack DM client — None if secret not configured or unreachable
-    slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "AB/SlackBotToken")
+    slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "IT/SLACK_BOT_TOKEN")
     slack_secret_region = os.getenv("GPUMON_SLACK_SECRET_REGION", os.getenv("GPUMON_SECRET_REGION", "eu-west-1"))
     dm_client = build_slack_dm_client(slack_secret_id, slack_secret_region) if page_employee else None
 

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -8,5 +8,4 @@ services:
     volumes:
       - /tmp:/tmp
     env_file:
-      - path: .env
-        required: false
+      - .env

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,7 +1,11 @@
 services:
   gpumon:
-    runtime: runc
-    deploy:
-      resources:
-        reservations:
-          devices: []
+    build: .
+    restart: unless-stopped
+    network_mode: host
+    pid: host
+    volumes:
+      - /tmp:/tmp
+    env_file:
+      - path: .env
+        required: false

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,5 +1,6 @@
 services:
   gpumon:
+    runtime: runc
     deploy:
       resources:
         reservations:

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,0 +1,6 @@
+services:
+  gpumon:
+    deploy:
+      resources:
+        reservations:
+          devices: []

--- a/docker-compose.cpu.yml
+++ b/docker-compose.cpu.yml
@@ -1,5 +1,6 @@
 services:
   gpumon:
+    runtime: runc
     build: .
     restart: unless-stopped
     network_mode: host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   gpumon:
     build: .
     restart: unless-stopped
+    runtime: nvidia
     network_mode: host
     pid: host
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,7 @@ services:
     volumes:
       - /tmp:/tmp
     env_file:
-      - path: .env
-        required: false
+      - .env
     deploy:
       resources:
         reservations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  gpumon:
+    build: .
+    restart: unless-stopped
+    network_mode: host
+    pid: host
+    volumes:
+      - /tmp:/tmp
+    env_file:
+      - path: .env
+        required: false
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,8 +16,10 @@ else
 fi
 main_pid=$!
 
-# Block until either child exits; then exit 1 so Docker restarts the container.
-# Requires bash >= 4.3 (Ubuntu 22.04 ships bash 5.x).
-wait -n "$hostmon_pid" "$main_pid"
+# Block until either child exits, then exit 1 so Docker restarts the container.
+# Portable replacement for 'wait -n' (bash >= 4.3): poll with kill -0 every second.
+while kill -0 "$hostmon_pid" 2>/dev/null && kill -0 "$main_pid" 2>/dev/null; do
+    sleep 1
+done
 echo "[entrypoint] a monitor process exited — restarting container"
 exit 1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
-set -e
+# If either monitor exits unexpectedly, fail the container so Docker restarts it.
+set -euo pipefail
 
 # Host metrics reporter runs alongside the GPU/CPU monitor
 python3 /app/hostmon.py &
+hostmon_pid=$!
 
 # Detect GPUs and launch the appropriate monitor
 if nvidia-smi --list-gpus >/dev/null 2>&1 && [ "$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
     echo "[entrypoint] GPU(s) detected — starting gpumon.py"
-    exec python3 /app/gpumon.py
+    python3 /app/gpumon.py &
 else
     echo "[entrypoint] No GPUs detected — starting cpumon.py"
-    exec python3 /app/cpumon.py
+    python3 /app/cpumon.py &
 fi
+main_pid=$!
+
+# Block until either child exits; then exit 1 so Docker restarts the container.
+# Requires bash >= 4.3 (Ubuntu 22.04 ships bash 5.x).
+wait -n "$hostmon_pid" "$main_pid"
+echo "[entrypoint] a monitor process exited — restarting container"
+exit 1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Host metrics reporter runs alongside the GPU/CPU monitor
+python3 /app/hostmon.py &
+
+# Detect GPUs and launch the appropriate monitor
+if nvidia-smi --list-gpus >/dev/null 2>&1 && [ "$(nvidia-smi --list-gpus | wc -l)" -gt 0 ]; then
+    echo "[entrypoint] GPU(s) detected — starting gpumon.py"
+    exec python3 /app/gpumon.py
+else
+    echo "[entrypoint] No GPUs detected — starting cpumon.py"
+    exec python3 /app/cpumon.py
+fi

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+title: gpumon
+description: Containerised GPU/CPU fleet monitoring, idle-shutdown automation, and Slack alerting for AWS EC2

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,8 +84,7 @@ GPU metrics loop. Runs inside the container on GPU instances.
 - Maintains a rolling 5-minute window of per-core CPU utilisation.
 - Tracks `alarm_pilot_light` (0/1): set to 1 when GPU, CPU, and network are all below policy thresholds for the configured backoff period.
 - Log line format is fixed for `halt_it.sh` compatibility: the `Alarm_Pilot_value` field falls at colon-split index 12.
-- On pilot light ON: sends team Slack webhook + employee DM (4 h cooldown, suppressed on SPOT).
-- On pilot light OFF: team webhook only.
+- On pilot light ON: sends employee DM (4 h cooldown, suppressed on SPOT/PAGE_EMPLOYEE=False).
 
 ### `cpumon.py`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,186 @@
+---
+title: Architecture — gpumon
+layout: default
+---
+
+# Architecture
+
+[← Home](index)
+
+---
+
+## Component map
+
+```
+┌──────────────────────────── EC2 Instance ────────────────────────────────┐
+│                                                                          │
+│   ┌────────────────────────── Docker Container ──────────────────────┐  │
+│   │                                                                  │  │
+│   │  docker-entrypoint.sh                                            │  │
+│   │    │                                                             │  │
+│   │    ├── nvidia-smi present?                                       │  │
+│   │    │     yes → python3 gpumon.py   (GPU loop, 10 s interval)     │  │
+│   │    │     no  → python3 cpumon.py   (CPU loop, 10 s interval)     │  │
+│   │    │                                                             │  │
+│   │    └── python3 hostmon.py &        (host metrics, 60 s interval) │  │
+│   │                                                                  │  │
+│   │  Python monitors read from:                                      │  │
+│   │    pynvml  → GPU stats (gpumon only)                             │  │
+│   │    psutil  → CPU, memory, disk, process list                     │  │
+│   │    boto3   → CloudWatch put_metric_data, EC2 tags                │  │
+│   │    IMDS v2 → instance-id, region, type, AZ                       │  │
+│   │                                                                  │  │
+│   │  Shared state in /tmp (bind-mounted to host):                    │  │
+│   │    GPU_TEMP_YYYY-MM-DDTHH       ← gpumon log (halt_it reads)     │  │
+│   │    CPUMON_LOGS_YYYY-MM-DDTHH   ← cpumon log (halt_it reads)     │  │
+│   │    HOSTMON_LOGS_YYYY-MM-DDTHH  ← hostmon log (never read by      │  │
+│   │                                               halt_it)           │  │
+│   │    gpumon_alert_state.json     ← DM cooldown timestamps          │  │
+│   │    gpumon_crontab.lock         ← fcntl lock for crontab writes   │  │
+│   │    timestamp.txt               ← kill_halt.sh backoff file       │  │
+│   │                                                                  │  │
+│   └──────────────────────────────────────────────────────────────────┘  │
+│                             │  /tmp:/tmp                                 │
+│   Host                      ▼                                           │
+│   ┌─────────────────────────────────────────────────────────────────┐   │
+│   │  crontab (*/10 * * * *)                                         │   │
+│   │    └── /usr/local/sbin/halt_it.sh                               │   │
+│   │         reads GPU_TEMP_* or CPUMON_LOGS_*                       │   │
+│   │         pilot light held 2 h → stop/terminate instance          │   │
+│   │                                                                 │   │
+│   │  systemd: gpumon-update.timer (5 min post-boot, then hourly)    │   │
+│   │    └── /usr/local/sbin/gpumon-update.sh                         │   │
+│   │         git -C /root/gpumon pull                                │   │
+│   │         new commits → docker compose up -d --build              │   │
+│   └─────────────────────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────────────────────┘
+
+         ▲                              ▲
+         │ CloudWatch                   │ Slack Bot API
+         │ put_metric_data              │ (Secrets Manager → xoxb- token)
+         │                              │
+┌────────────────┐             ┌─────────────────────┐
+│  CloudWatch    │             │  Slack workspace     │
+│  3 namespaces  │             │  employee DMs +      │
+│  custom metrics│             │  team channel hooks  │
+└────────────────┘             └─────────────────────┘
+
+AWS Lambda (EventBridge schedule, every 5–10 min)
+  └── lambda_manager.py
+        reads GPUMON tag on all instances in all regions
+        sends SSM RunShellScript commands
+        updates GPUMON tag with result
+```
+
+---
+
+## File roles
+
+### `gpumon.py`
+
+GPU metrics loop. Runs inside the container on GPU instances.
+
+- Initialises NVML; iterates over all GPU handles every 10 seconds.
+- Maintains a rolling 5-minute window of per-core CPU utilisation.
+- Tracks `alarm_pilot_light` (0/1): set to 1 when GPU, CPU, and network are all below policy thresholds for the configured backoff period.
+- Log line format is fixed for `halt_it.sh` compatibility: the `Alarm_Pilot_value` field falls at colon-split index 12.
+- On pilot light ON: sends team Slack webhook + employee DM (4 h cooldown, suppressed on SPOT).
+- On pilot light OFF: team webhook only.
+
+### `cpumon.py`
+
+Same structure as `gpumon.py` without NVML. Runs on CPU-only instances.
+
+- Log format: `Alarm_Pilot_value` at colon-split index 6 (fewer fields before it — no GPU columns).
+- Installs `halt_it.sh` host crontab entry via `ensure_halt_it_crontab()` (fcntl-locked against the parallel `gpumon.py` start).
+
+### `hostmon.py`
+
+Host-level metrics. Always runs as a background process alongside gpumon or cpumon.
+
+- Reports to `Host-metrics` CloudWatch namespace every 60 seconds.
+- Writes its own log (`HOSTMON_LOGS_*`) which `halt_it.sh` **never reads** — isolation is intentional.
+- Sends employee DMs for disk and memory alerts independently of the pilot light.
+
+### `mon_utils.py`
+
+Shared utility module imported by all three monitors.
+
+Key responsibilities:
+- **IMDS v2**: token fetch with 5.5-hour proactive refresh (before 6 h TTL expiry).
+- **Policy config**: `POLICIES` dict maps tag value → thresholds.
+- **Alert rate limiting**: reads/writes `/tmp/gpumon_alert_state.json` with atomic `os.replace()` + `fcntl.LOCK_EX` to prevent concurrent corruption by gpumon + cpumon.
+- **`ensure_halt_it_crontab`**: `fcntl.LOCK_EX` prevents the double-add race when both gpumon and cpumon start simultaneously.
+- **`build_slack_dm_client`**: fetches bot token from Secrets Manager and initialises `SlackDMClient`; returns `None` on any failure so callers never crash.
+
+### `slack_dm.py`
+
+Slack Bot DM client. Stateful within one process lifetime; caches user IDs and DM channel IDs.
+
+- `find_user_id`: email in `Employee` tag → `users.lookupByEmail` (fast); otherwise paginates `users.list` and matches `real_name` / `display_name` (case-insensitive).
+- `_open_dm_channel`: `conversations.open` result cached per `user_id`.
+- `send_dm`: orchestrates lookup → open → `chat.postMessage`.
+- Gracefully degrades if `slack-sdk` is not installed (ImportError caught at import time).
+
+### `halt_it.sh`
+
+Runs on the **host** crontab, not inside the container. Reads from `/tmp` which is shared via the bind-mount.
+
+- Parses log files line by line; uses `cut -d: -f6` (CPU) or `cut -d: -f12` (GPU) to extract `Alarm_Pilot_value`.
+- Counts recent lines where pilot = 1; if that count spans ≥ 2 hours → stop/terminate.
+- Credentials fetched from Secrets Manager at `GPUMON_SECRET_REGION` (defaults `eu-west-1`) — deliberately separate from the instance region.
+- AWS CLI health-checked with `aws sts get-caller-identity` before attempting any stop.
+
+### `lambda_manager.py`
+
+Fleet manager Lambda. No persistent state — everything is derived from EC2 tags.
+
+- Sweeps all configured `REGIONS` on every invocation.
+- Dispatches by `GPUMON` tag value to handler functions.
+- All SSM commands are sent as `AWS-RunShellScript` and polled until terminal status.
+- Progressive fix: step 1 (`git pull` + `docker compose up -d --build`) before step 2 (full `autoinstall.sh`).
+- Migration guard: refuses to run Docker fix commands on instances without Docker installed (avoids inadvertent migration).
+
+---
+
+## Data flow — metrics to shutdown
+
+```
+pynvml / psutil
+    │
+    ▼
+gpumon.py / cpumon.py
+    │  10 s loop
+    ├──► CloudWatch put_metric_data
+    └──► /tmp/GPU_TEMP_* (or CPUMON_LOGS_*)
+              │
+              │  every 10 min
+              ▼
+         halt_it.sh (host)
+              │
+              └── pilot light held 2 h?
+                    │
+                    ├── no  → exit 0
+                    └── yes → Secrets Manager → aws ec2 stop-instances
+```
+
+```
+psutil (disk, memory, processes)
+    │
+    ▼
+hostmon.py
+    │  60 s loop
+    ├──► CloudWatch put_metric_data (Host-metrics namespace)
+    ├──► /tmp/HOSTMON_LOGS_*
+    └──► Slack DM (disk/memory thresholds, 12 h cooldown each)
+```
+
+---
+
+## Security notes
+
+- **No secrets in env vars at build time.** All credentials fetched from Secrets Manager at runtime via IAM instance role.
+- **Bot token region**: the Slack secret may live in a different region (`GPUMON_SLACK_SECRET_REGION`) from the instance. The SM client is constructed with the explicit secret region.
+- **Stop credentials region**: similarly, `GPUMON_SECRET_REGION` (defaults `eu-west-1`) is used for stop/terminate credentials regardless of the instance's own region.
+- **Alert state atomicity**: `/tmp/gpumon_alert_state.json` is written via `os.replace()` on a temp file under `LOCK_EX` — safe for concurrent gpumon + cpumon access.
+- **halt_it.sh AWS CLI check**: `aws sts get-caller-identity` with a 30 s timeout before any stop attempt — prevents actions when the AWS CLI is broken or the IAM role has been detached.

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ From that point, the Lambda health-checks the instance on every sweep. If it det
 gpumon.py / cpumon.py
   └── every 10 s: is GPU/CPU below threshold AND network quiet?
         └── yes for restart_backoff seconds → alarm_pilot_light = 1
-              └── Slack: team channel alert + employee DM (4 h cooldown)
+              └── Slack: employee DM (4 h cooldown)
 
 halt_it.sh (host crontab, every 10 min)
   └── collects log lines timestamped within policy window
@@ -82,8 +82,7 @@ Alerts reach the right person automatically. The `Employee` EC2 tag (email or di
 
 | Event | Who gets it | Cooldown |
 |-------|------------|---------|
-| Instance idle, will stop in ~3 h | Team channel + Employee DM | 4 h |
-| Activity resumed | Team channel only | — |
+| Instance idle, will stop in ~3 h | Employee DM | 4 h |
 | Disk < threshold | Employee DM | 12 h |
 | Memory > threshold | Employee DM | 12 h |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,133 @@
+---
+title: gpumon
+layout: default
+---
+
+# gpumon
+
+**Containerised GPU/CPU fleet monitoring, idle-shutdown automation, and Slack alerting for AWS EC2.**
+
+No SSH. No dashboards to maintain. Drop a tag on an instance — the fleet manages itself.
+
+---
+
+## What it does
+
+Each monitored EC2 instance runs gpumon as a Docker container. Every 10–60 seconds it publishes custom CloudWatch metrics for GPU utilisation, CPU, memory, disk, power draw, and temperature. When a machine looks idle, it alerts the responsible employee on Slack and — if the idle condition persists for two hours — stops or terminates the instance automatically.
+
+A scheduled AWS Lambda function sweeps every region, reads a single `GPUMON` EC2 tag, and installs, health-checks, fixes, or removes the container entirely, without any SSH access.
+
+---
+
+## Core features
+
+| Feature | Detail |
+|---------|--------|
+| **GPU monitoring** | Per-GPU utilisation, VRAM, power, temperature via NVML |
+| **CPU monitoring** | Per-core utilisation, network throughput |
+| **Host metrics** | Root disk free, RAM usage, top memory/CPU process |
+| **CloudWatch** | Three custom namespaces: `GPU-metrics-with-team-tag`, `CPU-metrics`, `Host-metrics` |
+| **Idle shutdown** | Alarm pilot light → 2 h hold → stop/terminate via Secrets Manager credentials |
+| **Slack DMs** | Employee paged on idle, low disk, high memory (per-alert cooldowns) |
+| **Lambda fleet manager** | Install, health-check, progressive fix, migration, delete — via EC2 tags |
+| **Auto-update** | Systemd timer: `git pull` + `docker compose up -d --build` on new commits |
+| **SPOT-aware** | `GPUMON_POLICY=SPOT` disables employee DMs; raises idle thresholds |
+
+---
+
+## How deployment works
+
+```
+Set GPUMON=install on any EC2 instance
+        │
+        ▼
+Lambda runs autoinstall.sh via SSM
+        │
+        ├── Installs Docker + NVIDIA Container Toolkit (if GPU)
+        ├── Builds container from repo
+        ├── Starts container (network_mode: host, pid: host)
+        ├── Installs halt_it.sh to host crontab
+        └── Registers systemd auto-update timer
+        │
+        ▼
+GPUMON tag → ACTIVE
+```
+
+From that point, the Lambda health-checks the instance on every sweep. If it detects a failure it runs a progressive fix (fast git pull first, full reinstall second). If neither works, it sets `NOT_FIXED` for manual attention.
+
+---
+
+## Idle-shutdown flow
+
+```
+gpumon.py / cpumon.py
+  └── every 10 s: is GPU/CPU below threshold AND network quiet?
+        └── yes for restart_backoff seconds → alarm_pilot_light = 1
+              └── Slack: team channel alert + employee DM (4 h cooldown)
+
+halt_it.sh (host crontab, every 10 min)
+  └── parses /tmp/GPU_TEMP_* or CPUMON_LOGS_*
+        └── pilot light = 1 for last 2 h?
+              └── fetch creds from Secrets Manager
+                    └── aws ec2 stop-instances (or terminate)
+```
+
+To cancel: `sudo bash /root/gpumon/kill_halt.sh` — writes a 2-hour backoff file.
+
+---
+
+## Slack alerts
+
+Alerts reach the right person automatically. The `Employee` EC2 tag (email or display name) is resolved to a Slack user via the Bot API. The `Team` tag routes team-channel messages.
+
+| Event | Who gets it | Cooldown |
+|-------|------------|---------|
+| Instance idle, will stop in ~3 h | Team channel + Employee DM | 4 h |
+| Activity resumed | Team channel only | — |
+| Disk < threshold | Employee DM | 12 h |
+| Memory > threshold | Employee DM | 12 h |
+
+---
+
+## GPUMON policy presets
+
+| Policy | Idle backoff | CPU thresh | GPU thresh | Network thresh |
+|--------|-------------|-----------|-----------|---------------|
+| `STANDARD` | 1 h | 10 % | 10 % | 15 000 pkt |
+| `RELAXED` | 2 h | 5 % | 10 % | 10 000 pkt |
+| `SEVERE` | 0 | 20 % | 2 % | 15 000 pkt |
+| `SPOT` | 0 | 20 % | 10 % | 30 000 pkt |
+| `SUSPEND` | 24 h | 10 % | 10 % | 15 000 pkt |
+
+---
+
+## Getting started
+
+### Single instance (manual)
+
+```bash
+git clone https://github.com/autobrains/gpumon.git /root/gpumon
+cp /root/gpumon/.env.example /root/gpumon/.env
+# edit .env — add Slack bot token secret name, thresholds
+sudo bash /root/gpumon/autoinstall.sh
+```
+
+### Managed fleet (Lambda)
+
+1. Deploy `lambda_manager.py` as a Lambda function (Python 3.12).
+2. Grant the Lambda the EC2 and SSM permissions listed in the [README](https://github.com/autobrains/gpumon#lambda-fleet-manager).
+3. Schedule it with EventBridge (every 5–10 minutes).
+4. Tag any EC2 instance with `GPUMON = install` — the Lambda does the rest.
+
+---
+
+## Pages
+
+- [Architecture](architecture) — component design, file roles, data flow
+- [Operations guide](operations) — day-to-day tag operations, migration, troubleshooting
+
+---
+
+## Source
+
+[github.com/autobrains/gpumon](https://github.com/autobrains/gpumon) — Apache 2.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ Alerts reach the right person automatically. The `Employee` EC2 tag (email or di
 | `RELAXED` | 2 h | 5 % | 10 % | 10 000 pkt |
 | `SEVERE` | 0 | 20 % | 2 % | 15 000 pkt |
 | `SPOT` | 0 | 20 % | 10 % | 30 000 pkt |
-| `SUSPEND` | 24 h | 10 % | 10 % | 15 000 pkt |
+| `SUSPEND` | 10 days | 10 % | 10 % | 15 000 pkt |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,8 +66,8 @@ gpumon.py / cpumon.py
               └── Slack: team channel alert + employee DM (4 h cooldown)
 
 halt_it.sh (host crontab, every 10 min)
-  └── parses /tmp/GPU_TEMP_* or CPUMON_LOGS_*
-        └── pilot light = 1 for last 2 h?
+  └── collects log lines timestamped within policy window
+        └── no activity spike AND ≥ 90% sample coverage?
               └── fetch creds from Secrets Manager
                     └── aws ec2 stop-instances (or terminate)
 ```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -42,7 +42,7 @@ This writes a timestamp file that suppresses `halt_it.sh` for 2 hours. The Alarm
 
 ### Suspend idle-shutdown temporarily
 
-Set `GPUMON_POLICY = SUSPEND` on the instance. The restart backoff becomes 24 hours, effectively preventing automatic shutdown for a full day of inactivity.
+Set `GPUMON_POLICY = SUSPEND` on the instance. The restart backoff becomes 10 days, effectively preventing automatic shutdown for an extended period of inactivity.
 
 ### Disable employee DMs for an instance
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,200 @@
+---
+title: Operations Guide — gpumon
+layout: default
+---
+
+# Operations Guide
+
+[← Home](index)
+
+---
+
+## Day-to-day tag operations
+
+All fleet management is done by setting the `GPUMON` EC2 tag. The Lambda fleet manager acts on the tag within 5–10 minutes.
+
+### Install gpumon on a new instance
+
+1. Ensure the instance has the `EC2IAMRole` instance profile attached (the Lambda will attach it if missing, but the instance must be running).
+2. Set `GPUMON = install` on the instance.
+3. Optionally set `GPUMON_BRANCH = feature/dockerize` to install the Docker branch instead of `main`.
+4. Lambda installs Docker, builds the container, starts it, and sets the tag to `ACTIVE`.
+
+### Remove gpumon from an instance
+
+Set `GPUMON = DELETE`. Lambda runs `docker compose down`, disables the update timer, removes the halt_it.sh crontab entry, and wipes the repo directory. The tag is cleared to `""`.
+
+### Force a health check
+
+The Lambda health-checks all `ACTIVE` and `INACTIVE` instances on every sweep — no manual action needed.
+
+To force an immediate check outside the sweep schedule, you can invoke the Lambda manually from the AWS console with an empty event `{}`.
+
+### Cancel a pending shutdown
+
+If `halt_it.sh` is about to stop an instance and you need to keep it running:
+
+```bash
+sudo bash /root/gpumon/kill_halt.sh
+```
+
+This writes a timestamp file that suppresses `halt_it.sh` for 2 hours. The Alarm Pilot Light metric will reset when the instance becomes active again.
+
+### Suspend idle-shutdown temporarily
+
+Set `GPUMON_POLICY = SUSPEND` on the instance. The restart backoff becomes 24 hours, effectively preventing automatic shutdown for a full day of inactivity.
+
+### Disable employee DMs for an instance
+
+Set `PAGE_EMPLOYEE = False`. Team channel notifications continue; only the personal DM is suppressed. Useful for shared or unattended instances.
+
+---
+
+## Migrating legacy instances to Docker
+
+Legacy instances (running gpumon directly via systemd, not Docker) continue working unchanged until you decide to migrate.
+
+**To migrate a single instance:**
+
+1. Set `GPUMON = MIGRATE` on the instance.
+2. Optionally set `GPUMON_BRANCH = feature/dockerize` (this is the default for MIGRATE).
+3. Lambda will:
+   - Stop all legacy systemd units (`gpumon`, `cpumon`, `gpumon-monitor`).
+   - Kill any bare `python gpumon.py / cpumon.py / hostmon.py` processes.
+   - Remove legacy crontab entries.
+   - Re-clone the repo at the target branch.
+   - Run `autoinstall.sh` end-to-end.
+   - Tag the instance `ACTIVE` on success, `FAILED` on failure.
+
+**Alert cooldown state** (`/tmp/gpumon_alert_state.json`) and **log files** survive the migration because `/tmp` is bind-mounted. The employee will not receive duplicate alerts triggered by the brief monitoring gap.
+
+**If a legacy instance goes FAILED** (gpumon process crashed), the Lambda will set it to `NOT_FIXED` rather than auto-installing Docker. Manual action: either restart the legacy service manually, or set `GPUMON = MIGRATE` to move to Docker.
+
+---
+
+## Merging `feature/dockerize` into `main`
+
+When the Docker branch is ready for promotion:
+
+1. Merge the PR on GitHub.
+2. In `lambda_manager.py`, update:
+   ```python
+   DOCKER_BRANCH = "main"   # was "feature/dockerize"
+   ```
+3. Redeploy the Lambda.
+4. Retag existing Docker instances so their local repos switch to tracking `main`:
+   - Set `GPUMON_BRANCH = main` and `GPUMON = MIGRATE` on each Docker instance.
+   - Lambda re-clones from `main` and restarts the container (~5 min downtime per instance).
+5. Delete the `feature/dockerize` branch.
+
+From that point, all installs and migrations use `main`.
+
+---
+
+## Troubleshooting
+
+### GPUMON tag stuck at PENDING_SSM
+
+The SSM agent on the instance was not reachable when Lambda first tried to install. This happens when:
+- The instance was not yet fully booted.
+- The SSM agent is not installed or not running.
+- The instance profile does not include SSM permissions.
+
+**Fix:** Lambda will retry automatically on the next sweep. If it persists after 15 minutes, SSH in and check `systemctl status amazon-ssm-agent`.
+
+### GPUMON tag is FAILED
+
+Lambda attempted the progressive fix (git pull + rebuild, then full reinstall) and could not restore the container. Possible causes:
+- Docker daemon crashed or ran out of disk space.
+- Network issue prevented `git pull` or image pull.
+- `autoinstall.sh` failed mid-way.
+
+**Fix:**
+1. SSH in, check `docker logs gpumon-gpumon-1` and `journalctl -u gpumon-update`.
+2. Check `df -h` — full disk is common.
+3. Resolve the root cause, then set `GPUMON = install` to trigger a fresh install.
+
+### GPUMON tag is NOT_FIXED
+
+This appears on legacy instances that go FAILED (no Docker installed) or on Docker instances where both fix steps failed and the issue requires manual attention.
+
+**Fix:** investigate the root cause, then either:
+- Set `GPUMON = MIGRATE` to switch to Docker (legacy instances).
+- Set `GPUMON = install` for a clean reinstall (Docker instances).
+
+### Slack DMs not arriving
+
+1. Confirm the bot token in Secrets Manager is valid (`xoxb-...`) and has the required scopes: `users:read`, `users:read.email`, `im:write`, `chat:write`.
+2. Confirm the `Employee` tag matches the employee's Slack display name or email exactly (case-insensitive for display names).
+3. Check container logs: `docker logs gpumon-gpumon-1 2>&1 | grep slack_dm`.
+4. Confirm `PAGE_EMPLOYEE` is not `False` and `GPUMON_POLICY` is not `SPOT`.
+
+### halt_it.sh not running / instance not stopping
+
+1. Check host crontab: `crontab -l | grep halt_it`.
+2. Check halt_it log: `cat /var/log/halt_it.log`.
+3. Verify the AWS CLI works from the host: `aws sts get-caller-identity`.
+4. Verify Secrets Manager credentials: `aws secretsmanager get-secret-value --secret-id AB/InstanceRole --region eu-west-1`.
+5. Check that `/tmp/timestamp.txt` does not exist (kill_halt.sh backoff active).
+
+### Container not starting after autoinstall
+
+```bash
+docker compose logs         # see build/startup errors
+docker ps -a                # confirm container state
+sudo bash /root/gpumon/autoinstall.sh   # re-run (idempotent)
+```
+
+If Docker itself will not start: `systemctl status docker` and `journalctl -u docker`.
+
+---
+
+## Useful commands
+
+```bash
+# Container status
+docker ps --filter name=gpumon
+
+# Live container logs
+docker logs gpumon-gpumon-1 -f
+
+# Tail halt_it log
+tail -f /var/log/halt_it.log
+
+# Tail update log
+journalctl -u gpumon-update -f
+
+# Manually trigger an update
+sudo /usr/local/sbin/gpumon-update.sh
+
+# Force full reinstall
+sudo rm /var/log/gpumon.finished
+sudo bash /root/gpumon/autoinstall.sh
+
+# Cancel pending shutdown
+sudo bash /root/gpumon/kill_halt.sh
+
+# Check current GPUMON tag
+INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
+aws ec2 describe-tags \
+  --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=GPUMON" \
+  --region "$REGION" --query "Tags[0].Value" --output text
+```
+
+---
+
+## Environment variable quick reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GPUMON_SLACK_SECRET_ID` | `AB/SlackBotToken` | SM secret for Slack Bot token |
+| `GPUMON_SLACK_SECRET_REGION` | `eu-west-1` | Region of Slack secret |
+| `GPUMON_SECRET_ID` | `AB/InstanceRole` | SM secret for stop/terminate credentials |
+| `GPUMON_SECRET_REGION` | `eu-west-1` | Region of stop-credential secret |
+| `DISK_ALERT_FREE_PCT` | `10` | Alert threshold — disk free % |
+| `MEMORY_ALERT_USED_PCT` | `90` | Alert threshold — memory used % |
+| `ALERT_COOLDOWN_HOURS` | `12` | Hours between disk/memory repeat DMs |
+| `SHUTDOWN_ALERT_COOLDOWN_HOURS` | `4` | Hours between idle-shutdown repeat DMs |
+| `DEBUG_WEBHOOK_URL` | — | Fallback Slack webhook |
+| `<TEAM>_TEAM_WEBHOOK_URL` | — | Team channel webhook |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -46,7 +46,7 @@ Set `GPUMON_POLICY = SUSPEND` on the instance. The restart backoff becomes 10 da
 
 ### Disable employee DMs for an instance
 
-Set `PAGE_EMPLOYEE = False`. Team channel notifications continue; only the personal DM is suppressed. Useful for shared or unattended instances.
+Set `PAGE_EMPLOYEE = False`. The idle DM is suppressed. Useful for shared or unattended instances.
 
 ---
 
@@ -196,5 +196,3 @@ aws ec2 describe-tags \
 | `MEMORY_ALERT_USED_PCT` | `90` | Alert threshold — memory used % |
 | `ALERT_COOLDOWN_HOURS` | `12` | Hours between disk/memory repeat DMs |
 | `SHUTDOWN_ALERT_COOLDOWN_HOURS` | `4` | Hours between idle-shutdown repeat DMs |
-| `DEBUG_WEBHOOK_URL` | — | Fallback Slack webhook |
-| `<TEAM>_TEAM_WEBHOOK_URL` | — | Team channel webhook |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -17,7 +17,7 @@ All fleet management is done by setting the `GPUMON` EC2 tag. The Lambda fleet m
 
 1. Ensure the instance has the `EC2IAMRole` instance profile attached (the Lambda will attach it if missing, but the instance must be running).
 2. Set `GPUMON = install` on the instance.
-3. Optionally set `GPUMON_BRANCH = feature/dockerize` to install the Docker branch instead of `main`.
+3. `GPUMON_BRANCH` defaults to `feature/dockerize` for installs. Set it explicitly only if you need a different branch.
 4. Lambda installs Docker, builds the container, starts it, and sets the tag to `ACTIVE`.
 
 ### Remove gpumon from an instance

--- a/gpumon.py
+++ b/gpumon.py
@@ -250,7 +250,9 @@ def main() -> None:
                 temp,     ok2  = _get_temp(handle)
                 util, gpu_util, mem_util, ok3 = _get_utilization(handle)
                 push_to_cw = push_to_cw and ok1 and ok2 and ok3
-                if util is not None:
+                if not ok3:
+                    gpu_query_failed = True
+                elif util is not None:
                     valid_gpu_count += 1
                     total_gpu_util += float(gpu_util)
                 gpu_results.append((util, gpu_util, mem_util, pow_draw, temp))

--- a/gpumon.py
+++ b/gpumon.py
@@ -168,9 +168,9 @@ def main() -> None:
         policy = "STANDARD"
         create_tag(ec2, instance_id, "GPUMON_POLICY", policy)
 
-    # SPOT instances: never DM the employee
+    # SPOT/SEVERE: no idle shutdown DM (disk/memory alerts handled by hostmon.py)
     page_employee = (
-        policy != "SPOT"
+        policy not in ("SPOT", "SEVERE")
         and tags.get("PAGE_EMPLOYEE", "True").lower() != "false"
     )
 

--- a/gpumon.py
+++ b/gpumon.py
@@ -43,6 +43,7 @@ TMP_FILE_PREFIX = "/tmp/GPU_TEMP_"
 SLEEP_INTERVAL = 10
 STORE_RESO = 60
 CACHE_DURATION = 300  # seconds of CPU history to keep
+POLICY_REFRESH_LOOPS = 60   # re-read GPUMON_POLICY tag every ~10 min
 
 
 def _get_power_draw(handle) -> tuple[str, bool]:
@@ -195,8 +196,24 @@ def main() -> None:
     network_tripped   = 0
     network: float    = 99.0
 
+    loop_count = 0
     try:
         while True:
+            loop_count += 1
+            if loop_count % POLICY_REFRESH_LOOPS == 0:
+                try:
+                    fresh_tags = get_instance_tags(ec2, instance_id)
+                    new_policy = fresh_tags.get("GPUMON_POLICY", policy)
+                    if new_policy != policy:
+                        policy = new_policy
+                        cfg = get_policy_config(policy)
+                        restart_backoff   = cfg["restart_backoff"]
+                        cpu_threshold     = cfg["cpu_threshold"]
+                        gpu_threshold     = cfg["gpu_threshold"]
+                        network_threshold = cfg["network_threshold"]
+                except Exception as exc:
+                    print(f"policy refresh error: {exc}")
+
             current_time = datetime.now()
             log_file = TMP_FILE_PREFIX + current_time.strftime("%Y-%m-%dT%H")
             cpu_util_tripped = False

--- a/gpumon.py
+++ b/gpumon.py
@@ -236,7 +236,13 @@ def main() -> None:
             gpu_results: list[tuple] = []
 
             for i in range(device_count):
-                handle = nvmlDeviceGetHandleByIndex(i)
+                try:
+                    handle = nvmlDeviceGetHandleByIndex(i)
+                except NVMLError as err:
+                    print(f"GPU {i}: nvmlDeviceGetHandleByIndex failed: {err} — skipping")
+                    push_to_cw = False
+                    gpu_results.append((None, "0", "0", "0.00", "0"))
+                    continue
                 pow_draw, ok1  = _get_power_draw(handle)
                 temp,     ok2  = _get_temp(handle)
                 util, gpu_util, mem_util, ok3 = _get_utilization(handle)

--- a/gpumon.py
+++ b/gpumon.py
@@ -32,9 +32,7 @@ from mon_utils import (
     get_network_stats,
     get_per_core_cpu_utilization,
     get_policy_config,
-    resolve_webhooks,
     seconds_elapsed,
-    send_slack,
     try_record_alert,
 )
 
@@ -184,8 +182,6 @@ def main() -> None:
 
     shutdown_cooldown_hours = float(os.getenv("SHUTDOWN_ALERT_COOLDOWN_HOURS", "4"))
 
-    team_webhook, _ = resolve_webhooks(team)
-
     # Slack DM client — None if secret not configured or unreachable
     slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "AB/SlackBotToken")
     slack_secret_region = os.getenv("GPUMON_SLACK_SECRET_REGION", os.getenv("GPUMON_SECRET_REGION", "eu-west-1"))
@@ -262,12 +258,6 @@ def main() -> None:
                 if round(average_gpu_util) <= gpu_threshold and not cpu_util_tripped and network <= network_threshold:
                     if alarm_pilot_light == 0:
                         alarm_pilot_light = 1
-                        # Team channel notification (always)
-                        send_slack(team_webhook,
-                                   f"[ {current_time} ] INSTANCE: {instance_name} - {instance_id} ({hostname}) "
-                                   f"CPU, GPU and NETWORK seems idle, TURNED ALARM PILOT LIGHT to: ON, "
-                                   f"instance is expected to stop in: 3 hours")
-                        # Personal DM to employee (rate-limited, not on SPOT)
                         if dm_client and try_record_alert("shutdown_alert", shutdown_cooldown_hours):
                             dm_client.send_dm(
                                 emp_name,
@@ -277,10 +267,6 @@ def main() -> None:
                 else:
                     if alarm_pilot_light == 1:
                         alarm_pilot_light = 0
-                        # Team channel only — no DM to employee for OFF transition
-                        send_slack(team_webhook,
-                                   f"[ {current_time} ] INSTANCE: {instance_name} - {instance_id} ({hostname}) "
-                                   f"CPU, GPU and NETWORK over minimum threshold, TURNED ALARM PILOT LIGHT to: OFF")
             else:
                 alarm_pilot_light = 0
 

--- a/gpumon.py
+++ b/gpumon.py
@@ -1,513 +1,292 @@
 # Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License").
-# You may not use this file except in compliance with the License.
-# A copy of the License is located at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#  
-#  or in the "license" file accompanying this file. This file is distributed 
-#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-#  express or implied. See the License for the specific language governing 
-#  permissions and limitations under the License.
-###########
-# Some changes to script have been made by Paul Seifer to adapt to python3.9, such as conversion of values to utf-8 strings.
+# Licensed under the Apache License, Version 2.0
+# Adapted for Python 3 and extended by Paul Seifer, Autobrains LTD
 
-try:
-    from urllib.request import Request, urlopen
-except ImportError:
-    from urllib2 import Request, urlopen
-import psutil
-import boto3
-from pynvml import *
-from datetime import datetime, timedelta
+from __future__ import annotations
+
+import os
+from datetime import datetime
 from time import sleep
-import time
-import requests
-import subprocess
+
+import boto3
+import psutil
+from pynvml import (
+    NVMLError,
+    nvmlDeviceGetCount,
+    nvmlDeviceGetHandleByIndex,
+    nvmlDeviceGetPowerUsage,
+    nvmlDeviceGetTemperature,
+    nvmlDeviceGetUtilizationRates,
+    nvmlInit,
+    nvmlShutdown,
+    NVML_TEMPERATURE_GPU,
+)
+
+from mon_utils import (
+    build_slack_dm_client,
+    calculate_average_core_utilization,
+    cleanup_old_logs,
+    create_tag,
+    ensure_halt_it_crontab,
+    fetch_instance_metadata,
+    get_instance_tags,
+    get_network_stats,
+    get_per_core_cpu_utilization,
+    get_policy_config,
+    record_alert_sent,
+    resolve_webhooks,
+    seconds_elapsed,
+    send_slack,
+    should_send_alert,
+)
+
+NAMESPACE = "GPU-metrics-with-team-tag"
+TMP_FILE_PREFIX = "/tmp/GPU_TEMP_"
+SLEEP_INTERVAL = 10
+STORE_RESO = 60
+CACHE_DURATION = 300  # seconds of CPU history to keep
 
 
-# Constants
-CACHE_DURATION = 300  # 5 minutes in seconds
-THRESHOLD_PERCENTAGE = 10  # Threshold for average core utilization
-
-# Variables
-core_utilization_cache = [[] for _ in range(psutil.cpu_count())]  # List to store utilization data for each core
-cpu_util_tripped = 0
-
-#Functions
-
-def check_root_crontab(search_string):
+def _get_power_draw(handle) -> tuple[str, bool]:
     try:
-        # Run the command to list root's crontab
-        result = subprocess.run(['sudo', 'crontab', '-l'], capture_output=True, text=True, check=True)
-        # Check if the search string is in the output
-        if search_string in result.stdout:
-            return True
-        else:
-            return False
-    except subprocess.CalledProcessError as e:
-        print(f"An error occurred: {e}")
-        return False
-    except PermissionError:
-        print("Permission denied. Make sure you have sudo privileges.")
-        return False
-
-def add_to_root_crontab(new_cron_job):
-    try:
-        # Get the current crontab content
-        current_crontab = subprocess.run(['sudo', 'crontab', '-l'], capture_output=True, text=True, check=True)
-        # Append the new job to the existing content
-        new_crontab = current_crontab.stdout + new_cron_job + "\n"
-        # Write the new crontab content
-        process = subprocess.Popen(['sudo', 'crontab', '-'], stdin=subprocess.PIPE, text=True)
-        process.communicate(input=new_crontab)
-        if process.returncode == 0:
-            print("New cron job added successfully.")
-            return True
-        else:
-            print("Failed to add new cron job.")
-            return False
-    except subprocess.CalledProcessError as e:
-        print(f"An error occurred: {e}")
-        return False
-    except PermissionError:
-        print("Permission denied. Make sure you have sudo privileges.")
-        return False
-
-def seconds_elapsed():
-    return time.time() - psutil.boot_time()
-
-def get_per_core_cpu_utilization():
-    return psutil.cpu_percent(interval=1, percpu=True)
-
-def calculate_average_core_utilization():
-    return [sum(core_data) / len(core_data) if core_data else 0 for core_data in core_utilization_cache]
-
-### CHOOSE REGION ####
-EC2_REGION = 'eu-west-1'
-
-###CHOOSE NAMESPACE PARMETERS HERE###
-my_NameSpace = 'GPU-metrics-with-team-tag' 
-
-### CHOOSE PUSH INTERVAL ####
-sleep_interval = 10
-
-### CHOOSE STORAGE RESOLUTION (BETWEEN 1-60) ####
-store_reso = 60
-
-#Instance information
-BASE_URL = 'http://169.254.169.254/latest/meta-data/'
-req = Request('http://169.254.169.254/latest/api/token',None,{'X-aws-ec2-metadata-token-ttl-seconds' : '21600'},method='PUT')
-TOKEN = urlopen(req).read().decode("utf-8")
-req = Request(BASE_URL + 'instance-id', None,{'X-aws-ec2-metadata-token' : TOKEN },method='GET')
-INSTANCE_ID = urlopen(req).read().decode("utf-8")
-req = Request(BASE_URL + 'ami-id', None,{'X-aws-ec2-metadata-token' : TOKEN },method='GET')
-IMAGE_ID = urlopen(req).read().decode("utf-8")
-req = Request(BASE_URL + 'instance-type', None,{'X-aws-ec2-metadata-token' : TOKEN },method='GET')
-INSTANCE_TYPE = urlopen(req).read().decode("utf-8")
-req = Request(BASE_URL + 'placement/availability-zone', None,{'X-aws-ec2-metadata-token' : TOKEN },method='GET')
-INSTANCE_AZ = urlopen(req).read().decode("utf-8")
-req = Request(BASE_URL + 'hostname', None,{'X-aws-ec2-metadata-token' : TOKEN },method='GET')
-HOSTNAME = urlopen(req).read().decode("utf-8")
-
-EC2_REGION = INSTANCE_AZ[:-1]
-
-TIMESTAMP = datetime.now().strftime('%Y-%m-%dT%H')
-TMP_FILE = '/tmp/GPU_TEMP_'
-TMP_FILE_SAVED = TMP_FILE + TIMESTAMP
-# Create EC2 client to get tags
-ec2 = boto3.client('ec2', region_name=EC2_REGION)
-# Create CloudWatch client
-cloudwatch = boto3.client('cloudwatch', region_name=EC2_REGION)
-
-def get_network_stats(instance_id,network):
-    # Set the end time to the current time
-    end = datetime.utcnow()
-    # Set the start time to 5 minutes ago
-    start = end - timedelta(minutes=5)
-    # Format the time strings
-    start_str = start.strftime("%Y-%m-%dT%H:%M:%SZ")
-    end_str = end.strftime("%Y-%m-%dT%H:%M:%SZ")
-    #print("From:",start_str,"Till:",end_str,"instance:",instance_id)
-    data_in = cloudwatch.get_metric_statistics(
-        Period=60,
-        StartTime=start_str,
-        EndTime=end_str,
-        MetricName="NetworkPacketsIn",
-        Namespace="AWS/EC2",
-        Statistics=["Maximum"],
-        Unit="Count",
-        Dimensions=[{'Name': 'InstanceId', 'Value': str(instance_id)}]
-    )
-    #print("data_in:",data_in)
-    data_out = cloudwatch.get_metric_statistics(
-        Period=60,
-        StartTime=start_str,
-        EndTime=end_str,
-        MetricName="NetworkPacketsOut",
-        Namespace="AWS/EC2",
-        Statistics=["Maximum"],
-        Unit="Count",
-        Dimensions=[{'Name': 'InstanceId', 'Value': str(instance_id)}]
-    )
-    datapoints_in = data_in.get("Datapoints", [])
-    #print("datapoints_in:",datapoints_in)
-    datapoints_out = data_out.get("Datapoints",[])
-    first_datapoint_in = 1 #we dont want to switch off instance if we werent able to bring metrics in
-    first_datapoint_out = 1
-    if datapoints_in:
-        # Access the first data point (assuming there is at least one)
-        first_datapoint_in = datapoints_in[0]["Maximum"]
-        #print(f"packetsin:{round(first_datapoint_in)}")
-    else:
-        first_datapoint_in = network / 2
-        print("No data points found.")
-    if datapoints_out:
-        # Access the first data point (assuming there is at least one)
-        first_datapoint_out = datapoints_out[0]["Maximum"]
-        #print(f"packetsout:{round(first_datapoint_out)}")
-    else:
-        first_datapoint_in = network / 2
-        print("No data points found.")
-    network_sum = round(first_datapoint_in) + round(first_datapoint_out)
-    return network_sum
-
-# Flag to push to CloudWatch
-PUSH_TO_CW = True
-def get_instance_tags(instance_id):
-    try:
-        response = ec2.describe_tags(
-            Filters=[
-                {
-                    'Name': 'resource-id',
-                    'Values': [instance_id]
-                }
-            ]
-        )
-        tags = {tag['Key']: tag['Value'] for tag in response['Tags']}
-        return tags
-    except ClientError:
-        print(f"Couldn't get tags for instance {instance_id}")
-        raise
-def send_slack(webhook_url,message):
-    message=f"{message}"   
-    payload = {
-        "text": message
-    }
-
-    response = requests.post(webhook_url, json=payload)
-
-    if response.status_code == 200:
-        print("Message sent to Slack successfully.")
-    else:
-        print(f"Failed to send message to Slack. Status code: {response.status_code}")
-
-def create_tag(instance_id, tag_name, default_value):
-    """
-    Ensures that a particular tag is present in the instance tags.
-    If the tag is not present, it adds the tag with the specified default value.
-
-    :param instance_id: The ID of the instance.
-    :param tag_name: The tag name to check for.
-    :param default_value: The default value to set if the tag is not found.
-    :return: None
-    """
-    ec2.create_tags(
-        Resources=[instance_id],
-        Tags=[{'Key': tag_name, 'Value': default_value}]
-        )
-    print(f"Tag '{tag_name}' with value '{default_value}' added to instance {instance_id}.")
-
-def getPowerDraw(handle):
-    try:
-        powDraw = nvmlDeviceGetPowerUsage(handle) / 1000.0
-        powDrawStr = '%.2f' % powDraw
+        return "%.2f" % (nvmlDeviceGetPowerUsage(handle) / 1000.0), True
     except NVMLError as err:
-        powDrawStr = handleError(err)
-        PUSH_TO_CW = False
-    return powDrawStr
+        return str(err), False
 
-def getTemp(handle):
+
+def _get_temp(handle) -> tuple[str, bool]:
     try:
-        temp = str(nvmlDeviceGetTemperature(handle, NVML_TEMPERATURE_GPU))
+        return str(nvmlDeviceGetTemperature(handle, NVML_TEMPERATURE_GPU)), True
     except NVMLError as err:
-        temp = handleError(err) 
-        PUSH_TO_CW = False
-    return temp
+        return str(err), False
 
-def getUtilization(handle):
+
+def _get_utilization(handle) -> tuple[object | None, str, str, bool]:
     try:
         util = nvmlDeviceGetUtilizationRates(handle)
-        gpu_util = str(util.gpu)
-        mem_util = str(util.memory)
+        return util, str(util.gpu), str(util.memory), True
     except NVMLError as err:
-        error = handleError(err)
-        gpu_util = error
-        mem_util = error
-        PUSH_TO_CW = False
-    return util, gpu_util, mem_util
+        s = str(err)
+        return None, s, s, False
 
-def logResults(team, emp_name, i, util, gpu_util, mem_util, powDrawStr, temp, average_gpu_util,alarm_pilot_light,cpu_util_tripped,seconds,current_time,per_core_utilization,network,network_tripped):
+
+def _log_results(
+    log_file: str,
+    cw_client,
+    instance_id: str,
+    image_id: str,
+    instance_type: str,
+    team: str,
+    emp_name: str,
+    gpu_index: int,
+    util,
+    gpu_util: str,
+    mem_util: str,
+    pow_draw: str,
+    temp: str,
+    average_gpu_util: float,
+    alarm_pilot_light: int,
+    cpu_util_tripped: bool,
+    seconds: int,
+    current_time: datetime,
+    per_core_utilization: list[float],
+    network: float,
+    network_tripped: int,
+    push_to_cw: bool,
+) -> None:
+    line = (
+        f"[ {current_time} ] "
+        f"tag:{team},"
+        f"Employee:{emp_name},"
+        f"GPU_ID:{gpu_index},"
+        f"GPU_Util:{gpu_util},"
+        f"MemUtil:{mem_util},"
+        f"powDrawStr:{pow_draw},"
+        f"Temp:{temp},"
+        f"AverageGPUUtil:{average_gpu_util},"
+        f"Alarm_Pilot_value:{alarm_pilot_light},"
+        f"CPU_Util_Tripped:{cpu_util_tripped},"
+        f"Seconds Elapsed since reboot:{seconds},"
+        f"Per-Core CPU Util:{per_core_utilization},"
+        f"NetworkStats:{network},"
+        f"Network_Tripped:{network_tripped}\n"
+    )
     try:
-        gpu_logs = open(TMP_FILE_SAVED, 'a+')
-        writeString = '[ ' + str(current_time) + ' ] ' + 'tag:' + team + ',' + 'Employee:' + emp_name + ',' + 'GPU_ID:' + str(i) + ',' + 'GPU_Util:' + gpu_util + ',' + 'MemUtil:' + mem_util + ',' + 'powDrawStr:' + powDrawStr + ',' + 'Temp:' + temp + ',' + 'AverageGPUUtil:' + str(average_gpu_util) + ',' + 'Alarm_Pilot_value:' + str(alarm_pilot_light) + ',' + 'CPU_Util_Tripped:' + str(cpu_util_tripped) + ',' + 'Seconds Elapsed since reboot:' + str(seconds) + ',' + 'Per-Core CPU Util:' + str(per_core_utilization) + ',' + 'NetworkStats:' + str(network) + ',' + 'Network_Tripped:' + str(network_tripped) + '\n'
-        #print(writeString)
-        #writeString = 'tag:' + team + ',' + 'Employee:' + emp_name + ',' + str(i) + ',' + gpu_util + ',' + mem_util + ',' + powDrawStr + ',' + temp + '\n'
-        gpu_logs.write(writeString)
-    except:
-        print("Error writing to file ", gpu_logs)
-    finally:
-        gpu_logs.close()
-    if (PUSH_TO_CW):
-        MY_DIMENSIONS=[
-                    {
-                        'Name': 'InstanceId',
-                        'Value': INSTANCE_ID
-                    },
-                    {
-                        'Name': 'ImageId',
-                        'Value': IMAGE_ID
-                    },
-                    {
-                        'Name': 'InstanceType',
-                        'Value': INSTANCE_TYPE
-                    },
-                    {
-                        'Name': 'GPUNumber',
-                        'Value': str(i)
-                    },
-                    {
-                        'Name': 'InstanceTag',
-                        'Value': str(team)
-                    },
-                    {
-                        'Name': 'EmployeeTag',
-                        'Value': str(emp_name)
-                    }
+        with open(log_file, "a") as fh:
+            fh.write(line)
+    except OSError as exc:
+        print(f"log write error: {exc}")
 
-                ]
-        cloudwatch.put_metric_data(
+    if not push_to_cw or util is None:
+        return
+
+    dims = [
+        {"Name": "InstanceId",    "Value": instance_id},
+        {"Name": "ImageId",       "Value": image_id},
+        {"Name": "InstanceType",  "Value": instance_type},
+        {"Name": "GPUNumber",     "Value": str(gpu_index)},
+        {"Name": "InstanceTag",   "Value": team},
+        {"Name": "EmployeeTag",   "Value": emp_name},
+    ]
+    try:
+        cw_client.put_metric_data(
+            Namespace=NAMESPACE,
             MetricData=[
-                {
-                    'MetricName': 'GPU Usage',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'Percent',
-                    'StorageResolution': store_reso,
-                    'Value': util.gpu
-                },
-                {
-                    'MetricName': 'Memory Usage',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'Percent',
-                    'StorageResolution': store_reso,
-                    'Value': util.memory
-                },
-                {
-                    'MetricName': 'Power Usage (Watts)',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'None',
-                    'StorageResolution': store_reso,
-                    'Value': float(powDrawStr)
-                },
-                {
-                    'MetricName': 'Temperature (C)',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'None',
-                    'StorageResolution': store_reso,
-                    'Value': int(temp)
-                },
-                {
-                    'MetricName': 'Alarm Pilot Light (1/0)',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'None',
-                    'StorageResolution': store_reso,
-                    'Value': float(alarm_pilot_light)
-                },
-                {
-                    'MetricName': 'Average GPU Utilization',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'Percent',
-                    'StorageResolution': store_reso,
-                    'Value': float(average_gpu_util)
-                },
-                {
-                    'MetricName': 'CPU Utilization Low Tripped',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'None',
-                    'StorageResolution': store_reso,
-                    'Value': float(cpu_util_tripped)
-                },
-                {
-                    'MetricName': 'Network Tripped',
-                    'Dimensions': MY_DIMENSIONS,
-                    'Unit': 'None',
-                    'StorageResolution': store_reso,
-                    'Value': float(network_tripped)
-                }
-
-
-        ],
-            Namespace=my_NameSpace
+                {"MetricName": "GPU Usage",                    "Dimensions": dims, "Unit": "Percent", "StorageResolution": STORE_RESO, "Value": util.gpu},
+                {"MetricName": "Memory Usage",                 "Dimensions": dims, "Unit": "Percent", "StorageResolution": STORE_RESO, "Value": util.memory},
+                {"MetricName": "Power Usage (Watts)",          "Dimensions": dims, "Unit": "None",    "StorageResolution": STORE_RESO, "Value": float(pow_draw)},
+                {"MetricName": "Temperature (C)",              "Dimensions": dims, "Unit": "None",    "StorageResolution": STORE_RESO, "Value": int(temp)},
+                {"MetricName": "Alarm Pilot Light (1/0)",      "Dimensions": dims, "Unit": "None",    "StorageResolution": STORE_RESO, "Value": float(alarm_pilot_light)},
+                {"MetricName": "Average GPU Utilization",      "Dimensions": dims, "Unit": "Percent", "StorageResolution": STORE_RESO, "Value": float(average_gpu_util)},
+                {"MetricName": "CPU Utilization Low Tripped",  "Dimensions": dims, "Unit": "None",    "StorageResolution": STORE_RESO, "Value": float(cpu_util_tripped)},
+                {"MetricName": "Network Tripped",              "Dimensions": dims, "Unit": "None",    "StorageResolution": STORE_RESO, "Value": float(network_tripped)},
+            ],
         )
-    
+    except Exception as exc:
+        print(f"CloudWatch put_metric_data error: {exc}")
 
-nvmlInit()
-deviceCount = nvmlDeviceGetCount()
-def main():
-    result = check_root_crontab("halt_it.sh")
-    if result:
-       print("halt_it.sh presence in crontab detected, continue")
-    else:
-       print("updating crontab with new halt_it.sh call")
-       new_job = "*/10 * * * * bash /root/gpumon/halt_it.sh | tee -a /tmp/halt_it_log.txt"
-       add_to_root_crontab(new_job)
 
-    global core_utilization_cache
+def main() -> None:
+    cleanup_old_logs(TMP_FILE_PREFIX, max_age_hours=48)
+    ensure_halt_it_crontab(
+        "*/10 * * * * bash /root/gpumon/halt_it.sh | tee -a /tmp/halt_it_log.txt"
+    )
+
+    meta = fetch_instance_metadata()
+    region        = meta["region"]
+    instance_id   = meta["instance_id"]
+    image_id      = meta["image_id"]
+    instance_type = meta["instance_type"]
+    hostname      = meta["hostname"]
+
+    ec2 = boto3.client("ec2",        region_name=region)
+    cw  = boto3.client("cloudwatch", region_name=region)
+
+    nvmlInit()
+    device_count = nvmlDeviceGetCount()
+
+    tags = get_instance_tags(ec2, instance_id)
+    instance_name = tags.get("Name", "NO_NAME_TAG")
+    team          = tags.get("Team", "NO_TAG")
+    emp_name      = tags.get("Employee", "NO_TAG")
+    policy        = tags.get("GPUMON_POLICY")
+    if policy is None:
+        policy = "STANDARD"
+        create_tag(ec2, instance_id, "GPUMON_POLICY", policy)
+
+    # SPOT instances: never DM the employee
+    page_employee = (
+        policy != "SPOT"
+        and tags.get("PAGE_EMPLOYEE", "True").lower() != "false"
+    )
+
+    cfg = get_policy_config(policy)
+    restart_backoff   = cfg["restart_backoff"]
+    cpu_threshold     = cfg["cpu_threshold"]
+    gpu_threshold     = cfg["gpu_threshold"]
+    network_threshold = cfg["network_threshold"]
+
+    shutdown_cooldown_hours = float(os.getenv("SHUTDOWN_ALERT_COOLDOWN_HOURS", "4"))
+
+    team_webhook, _ = resolve_webhooks(team)
+
+    # Slack DM client — None if secret not configured or unreachable
+    slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "AB/SlackBotToken")
+    slack_secret_region = os.getenv("GPUMON_SLACK_SECRET_REGION", os.getenv("GPUMON_SECRET_REGION", "eu-west-1"))
+    dm_client = build_slack_dm_client(slack_secret_id, slack_secret_region) if page_employee else None
+
+    core_cache: list[list[float]] = [[] for _ in range(psutil.cpu_count())]
     alarm_pilot_light = 0
-    network_tripped = 0
-    network = 99
-    cpu_util_tripped = False
-    policy = 'STANDARD'
-    tags = get_instance_tags(INSTANCE_ID)
-    if 'Name' in tags:
-        instance_name = str(tags['Name'])
-    else:
-        instance_name = "NO_NAME_TAG"
-    if 'Team' in tags:
-        team = str(tags['Team'])
-    else:
-        team = "NO_TAG"
-    if 'Employee' in tags:
-        emp_name = str(tags['Employee'])
-    else:
-        emp_name = "NO_TAG"
-    if 'GPUMON_POLICY' in tags:
-        policy = str(tags['GPUMON_POLICY'])
-    else:
-        create_tag(INSTANCE_ID,'GPUMON_POLICY',policy)
-    
-    if policy == 'RELAXED':
-        print('POLICY TAG detected:',{policy})
-        RESTART_BACKOFF = 7200 # will wait 2 hours to even start the evaluation
-        THRESHOLD_PERCENTAGE = 5 #over 5 percent CPU utilization will stop the shutdown sequence
-        GPU_THRESHOLD = 10 # Over 10 percent GPU average utilization will stop the shutdown sequence
-        NETWORK_THRESHOLD = 10000 # Over 10K packets in/out combined will stop the shutdown sequence
-    elif policy == "SEVERE":
-        print('POLICY TAG detected:',{policy})
-        RESTART_BACKOFF = 0 # will not wait and will start evaluation immediately upon boot
-        THRESHOLD_PERCENTAGE = 20 #over 20% CPU utilization will stop the shutdown sequence
-        GPU_THRESHOLD = 2 
-        NETWORK_THRESHOLD = 15000 #over 15K packets in/out combined will stop the shutdown sequence
-    elif policy == "SPOT": #this is the most aggressive shutdown, 15 min of inactivity
-        print('POLICY TAG detected:',{policy})
-        RESTART_BACKOFF = 0 #0 seconds backoff - the alert pilot switches to 1 right away if idle
-        THRESHOLD_PERCENTAGE = 20 # under 20% is considered idle
-        GPU_THRESHOLD = 10 # Over 10 percent GPU average utilization will stop the shutdown sequence
-        NETWORK_THRESHOLD = 30000 # Over 30K packets in/out combined will stop the shutdown sequence
-    elif policy == "SUSPEND": #this should keep it running even if no activity is detected
-        print('POLICY TAG detected:',{policy})
-        RESTART_BACKOFF = 864000 #10 days backoff then if the box is really quiet it can die
-        THRESHOLD_PERCENTAGE = 10
-        GPU_THRESHOLD = 10
-        NETWORK_THRESHOLD = 15000
-    else:
-        print('POLICY TAG detected:',{policy})
-        RESTART_BACKOFF = 3600 #This is STANDARD policy tag - 1 hour backoff, 10% cPu threshold 10% GPU and 15K network
-        THRESHOLD_PERCENTAGE = 10
-        GPU_THRESHOLD = 10
-        NETWORK_THRESHOLD = 15000
+    network_tripped   = 0
+    network: float    = 99.0
 
-    #print("team_var:",team_var)
-    debug_webhook = os.getenv("DEBUG_WEBHOOK_URL")
-    team_var = str(team) + "_TEAM_WEBHOOK_URL"
-    try:
-        team_webhook = os.getenv(team_var)
-    except:
-        try:
-            send_slack(debug_webhook,f"achtung, could not resolve team_webhook_url on {instance_name} {INSTANCE_ID} - {team_var}")
-            team_webhook = debug_webhook
-        except:
-            print(f"AAAARGH! DEBUG WEBHOOK is None:${DEBUG_WEBHOOK_URL} or cannot send data out, debug")
     try:
         while True:
-            total_gpu_util = 0
+            current_time = datetime.now()
+            log_file = TMP_FILE_PREFIX + current_time.strftime("%Y-%m-%dT%H")
             cpu_util_tripped = False
+
+            # ── CPU utilization cache ────────────────────────────────────────
             try:
-                # Get per-core CPU utilization
-                per_core_utilization = get_per_core_cpu_utilization()
-
-                # Cache utilization data for each core
-                for i, core_util in enumerate(per_core_utilization):
-                    core_utilization_cache[i].append(core_util)
-
-                # Remove outdated data from the cache
-                current_time = datetime.now()
-                core_utilization_cache = [core_data[-int(CACHE_DURATION / 1):] for core_data in core_utilization_cache]
-                # Calculate average core utilization
-                average_core_utilization = calculate_average_core_utilization()
-                #print(average_core_utilization)
-                # Check if any core exceeds the threshold
-                if any(utilization > THRESHOLD_PERCENTAGE for utilization in average_core_utilization):
+                per_core = get_per_core_cpu_utilization()
+                for i, v in enumerate(per_core):
+                    core_cache[i].append(v)
+                core_cache = [d[-int(CACHE_DURATION / SLEEP_INTERVAL):] for d in core_cache]
+                avg_cores = calculate_average_core_utilization(core_cache)
+                if any(u > cpu_threshold for u in avg_cores):
                     cpu_util_tripped = True
-                    #print("CPU Threshold exceeded. Changing variable to True.")
-            except:
-                    print('Could not get cpu core utilization statistics, debug')
+            except Exception as exc:
+                print(f"CPU utilization error: {exc}")
+                per_core = []
+                avg_cores = []
 
+            # ── GPU metrics ──────────────────────────────────────────────────
+            # Capture all per-GPU results in one pass to avoid double-querying
+            # and to ensure pilot-light decision uses the same data as the log.
+            total_gpu_util = 0.0
+            push_to_cw = True
+            gpu_results: list[tuple] = []
 
-            PUSH_TO_CW = True
-
-            # Find the metrics for each GPU on instance
-            for i in range(deviceCount):
+            for i in range(device_count):
                 handle = nvmlDeviceGetHandleByIndex(i)
+                pow_draw, ok1  = _get_power_draw(handle)
+                temp,     ok2  = _get_temp(handle)
+                util, gpu_util, mem_util, ok3 = _get_utilization(handle)
+                push_to_cw = push_to_cw and ok1 and ok2 and ok3
+                if util is not None:
+                    total_gpu_util += float(gpu_util)
+                gpu_results.append((util, gpu_util, mem_util, pow_draw, temp))
 
-                powDrawStr = getPowerDraw(handle)
-                temp = getTemp(handle)
-                util, gpu_util, mem_util = getUtilization(handle)
-                total_gpu_util += float(gpu_util)
-                
-            average_gpu_util = total_gpu_util / deviceCount
-            seconds = round(float(seconds_elapsed()))
+            average_gpu_util = total_gpu_util / device_count if device_count else 0.0
+            seconds = round(seconds_elapsed())
 
-            # calculate combined network in and out last 5 min
-            network = get_network_stats(instance_id=INSTANCE_ID,network=network)
-            if network_tripped == 0 and network <= NETWORK_THRESHOLD:
+            # ── Network ──────────────────────────────────────────────────────
+            network = get_network_stats(cw, instance_id, network)
+            if network_tripped == 0 and network <= network_threshold:
                 network_tripped = 1
-            #print(f"name_tag:{instance_name} network:{network}")
-            if seconds >= RESTART_BACKOFF:
-                #print("DEBUG:round(float(average_gpu_util)) <= GPU_THRESHOLD and cpu_util_tripped == False and network <= NETWORK_THRESHOLD")
-                #print(f"DEBUG:{round(float(average_gpu_util))} <= {GPU_THRESHOLD} and {cpu_util_tripped} == False and {network} <= {NETWORK_THRESHOLD}")
-                if round(float(average_gpu_util)) <= GPU_THRESHOLD and cpu_util_tripped == False and network <= NETWORK_THRESHOLD:    
-            #cpu util tripped == True means that there was higher than threshold cpu core activity and we cant stop the instance because of it
+
+            # ── Alarm pilot light ────────────────────────────────────────────
+            if seconds >= restart_backoff:
+                if round(average_gpu_util) <= gpu_threshold and not cpu_util_tripped and network <= network_threshold:
                     if alarm_pilot_light == 0:
-                        #print(f'CPU or GPU below {THRESHOLD_PERCENTAGE}% threshold, turning pilot light ON')
                         alarm_pilot_light = 1
-                        mmessage=f"[ {current_time} ] INSTANCE: {instance_name} - {INSTANCE_ID} ({HOSTNAME}) CPU, GPU and NETWORK seems idle, TURNED ALARM PILOT LIGHT to: ON, instance is expected to stop in: 3 hours"
-                        try:
-                            send_slack(team_webhook, mmessage)
-                        except:
-                            print(f"Could not send slack to webhook:{team_webhook}")
+                        # Team channel notification (always)
+                        send_slack(team_webhook,
+                                   f"[ {current_time} ] INSTANCE: {instance_name} - {instance_id} ({hostname}) "
+                                   f"CPU, GPU and NETWORK seems idle, TURNED ALARM PILOT LIGHT to: ON, "
+                                   f"instance is expected to stop in: 3 hours")
+                        # Personal DM to employee (rate-limited, not on SPOT)
+                        if dm_client and should_send_alert("shutdown_alert", shutdown_cooldown_hours):
+                            dm_client.send_dm(
+                                emp_name,
+                                f":alarm_clock: Your instance *{instance_name}* appears idle "
+                                f"and is scheduled to shut down in ~3 hours.",
+                            )
+                            record_alert_sent("shutdown_alert")
                 else:
                     if alarm_pilot_light == 1:
                         alarm_pilot_light = 0
-                        mmessage=f"[ {current_time} ] INSTANCE: {instance_name} - {INSTANCE_ID} ({HOSTNAME}) CPU, GPU and NETWORK over minimum threshold, TURNED ALARM PILOT LIGHT to: OFF"
-                        try:
-                            send_slack(team_webhook, mmessage)
-                        except:
-                            print(f"Could not send slack to webhook:{team_webhook}")
-                    #print(f'CPU or GPU above {THRESHOLD_PERCENTAGE}% threshold, turning pilot light OFF')
+                        # Team channel only — no DM to employee for OFF transition
+                        send_slack(team_webhook,
+                                   f"[ {current_time} ] INSTANCE: {instance_name} - {instance_id} ({hostname}) "
+                                   f"CPU, GPU and NETWORK over minimum threshold, TURNED ALARM PILOT LIGHT to: OFF")
             else:
                 alarm_pilot_light = 0
-            # Log the results
-            for i in range(deviceCount):
-                handle = nvmlDeviceGetHandleByIndex(i)
-                try:
-                    logResults(team, emp_name, i, util, gpu_util, mem_util, powDrawStr, temp, average_gpu_util, alarm_pilot_light, cpu_util_tripped, seconds,current_time,per_core_utilization,network,network_tripped)
-                except:
-                    print("could not write to disk")
-            sleep(sleep_interval)
+
+            # ── Log & push (reuse captured results — no second NVML query) ──
+            for i, (util_i, gpu_util_i, mem_util_i, pow_draw_i, temp_i) in enumerate(gpu_results):
+                _log_results(
+                    log_file, cw, instance_id, image_id, instance_type,
+                    team, emp_name, i, util_i, gpu_util_i, mem_util_i,
+                    pow_draw_i, temp_i, average_gpu_util, alarm_pilot_light,
+                    cpu_util_tripped, seconds, current_time, per_core,
+                    network, network_tripped, push_to_cw,
+                )
+
+            sleep(SLEEP_INTERVAL)
     finally:
         nvmlShutdown()
 
-if __name__=='__main__':
+
+if __name__ == "__main__":
     main()

--- a/gpumon.py
+++ b/gpumon.py
@@ -232,6 +232,8 @@ def main() -> None:
             # Capture all per-GPU results in one pass to avoid double-querying
             # and to ensure pilot-light decision uses the same data as the log.
             total_gpu_util = 0.0
+            valid_gpu_count = 0
+            gpu_query_failed = False
             push_to_cw = True
             gpu_results: list[tuple] = []
 
@@ -240,6 +242,7 @@ def main() -> None:
                     handle = nvmlDeviceGetHandleByIndex(i)
                 except NVMLError as err:
                     print(f"GPU {i}: nvmlDeviceGetHandleByIndex failed: {err} — skipping")
+                    gpu_query_failed = True
                     push_to_cw = False
                     gpu_results.append((None, "0", "0", "0.00", "0"))
                     continue
@@ -248,10 +251,14 @@ def main() -> None:
                 util, gpu_util, mem_util, ok3 = _get_utilization(handle)
                 push_to_cw = push_to_cw and ok1 and ok2 and ok3
                 if util is not None:
+                    valid_gpu_count += 1
                     total_gpu_util += float(gpu_util)
                 gpu_results.append((util, gpu_util, mem_util, pow_draw, temp))
 
-            average_gpu_util = total_gpu_util / device_count if device_count else 0.0
+            # Only average over GPUs that actually reported utilization.
+            # Divide by device_count would count failed GPUs as 0% — idle — which
+            # could trigger a false shutdown when the true state is unknown.
+            average_gpu_util = total_gpu_util / valid_gpu_count if valid_gpu_count else 0.0
             seconds = round(seconds_elapsed())
 
             # ── Network ──────────────────────────────────────────────────────
@@ -263,7 +270,7 @@ def main() -> None:
 
             # ── Alarm pilot light ────────────────────────────────────────────
             if seconds >= restart_backoff:
-                if round(average_gpu_util) <= gpu_threshold and not cpu_util_tripped and network <= network_threshold:
+                if round(average_gpu_util) <= gpu_threshold and not cpu_util_tripped and network <= network_threshold and not gpu_query_failed:
                     if alarm_pilot_light == 0:
                         alarm_pilot_light = 1
                         if dm_client and try_record_alert("shutdown_alert", shutdown_cooldown_hours):

--- a/gpumon.py
+++ b/gpumon.py
@@ -183,7 +183,7 @@ def main() -> None:
     shutdown_cooldown_hours = float(os.getenv("SHUTDOWN_ALERT_COOLDOWN_HOURS", "4"))
 
     # Slack DM client — None if secret not configured or unreachable
-    slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "AB/SlackBotToken")
+    slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "IT/SLACK_BOT_TOKEN")
     slack_secret_region = os.getenv("GPUMON_SLACK_SECRET_REGION", os.getenv("GPUMON_SECRET_REGION", "eu-west-1"))
     dm_client = build_slack_dm_client(slack_secret_id, slack_secret_region) if page_employee else None
 

--- a/gpumon.py
+++ b/gpumon.py
@@ -27,17 +27,15 @@ from mon_utils import (
     calculate_average_core_utilization,
     cleanup_old_logs,
     create_tag,
-    ensure_halt_it_crontab,
     fetch_instance_metadata,
     get_instance_tags,
     get_network_stats,
     get_per_core_cpu_utilization,
     get_policy_config,
-    record_alert_sent,
     resolve_webhooks,
     seconds_elapsed,
     send_slack,
-    should_send_alert,
+    try_record_alert,
 )
 
 NAMESPACE = "GPU-metrics-with-team-tag"
@@ -148,9 +146,6 @@ def _log_results(
 
 def main() -> None:
     cleanup_old_logs(TMP_FILE_PREFIX, max_age_hours=48)
-    ensure_halt_it_crontab(
-        "*/10 * * * * bash /root/gpumon/halt_it.sh | tee -a /tmp/halt_it_log.txt"
-    )
 
     meta = fetch_instance_metadata()
     region        = meta["region"]
@@ -256,13 +251,12 @@ def main() -> None:
                                    f"CPU, GPU and NETWORK seems idle, TURNED ALARM PILOT LIGHT to: ON, "
                                    f"instance is expected to stop in: 3 hours")
                         # Personal DM to employee (rate-limited, not on SPOT)
-                        if dm_client and should_send_alert("shutdown_alert", shutdown_cooldown_hours):
+                        if dm_client and try_record_alert("shutdown_alert", shutdown_cooldown_hours):
                             dm_client.send_dm(
                                 emp_name,
                                 f":alarm_clock: Your instance *{instance_name}* appears idle "
                                 f"and is scheduled to shut down in ~3 hours.",
                             )
-                            record_alert_sent("shutdown_alert")
                 else:
                     if alarm_pilot_light == 1:
                         alarm_pilot_light = 0

--- a/gpumon.py
+++ b/gpumon.py
@@ -179,6 +179,7 @@ def main() -> None:
     cpu_threshold     = cfg["cpu_threshold"]
     gpu_threshold     = cfg["gpu_threshold"]
     network_threshold = cfg["network_threshold"]
+    shutdown_eta      = cfg["shutdown_eta"]
 
     shutdown_cooldown_hours = float(os.getenv("SHUTDOWN_ALERT_COOLDOWN_HOURS", "4"))
 
@@ -207,6 +208,7 @@ def main() -> None:
                         cpu_threshold     = cfg["cpu_threshold"]
                         gpu_threshold     = cfg["gpu_threshold"]
                         network_threshold = cfg["network_threshold"]
+                        shutdown_eta      = cfg["shutdown_eta"]
                 except Exception as exc:
                     print(f"policy refresh error: {exc}")
 
@@ -279,7 +281,7 @@ def main() -> None:
                             dm_client.send_dm(
                                 emp_name,
                                 f":alarm_clock: Your instance *{instance_name}* appears idle "
-                                f"and is scheduled to shut down in ~3 hours.",
+                                f"and is scheduled to shut down in {shutdown_eta}.",
                             )
                 else:
                     if alarm_pilot_light == 1:

--- a/gpumon.py
+++ b/gpumon.py
@@ -250,8 +250,10 @@ def main() -> None:
 
             # ── Network ──────────────────────────────────────────────────────
             network = get_network_stats(cw, instance_id, network)
-            if network_tripped == 0 and network <= network_threshold:
+            if network <= network_threshold:
                 network_tripped = 1
+            else:
+                network_tripped = 0
 
             # ── Alarm pilot light ────────────────────────────────────────────
             if seconds >= restart_backoff:

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -244,6 +244,19 @@ if [ "${NOGO}" == "TRUE" ]; then
     echo "[ $(date) ] NO-GO: ${REASON}"
 else
     echo "[ $(date) ] GO — shutting down. Reason: ${REASON}" | tee -a /root/gpumon_persistent.log
+
+    # Dry-run before broadcasting — prevents wall-message spam when creds lack permission.
+    # DryRunOperation = authorized; UnauthorizedOperation = not authorized.
+    if [ "${POLICY}" == "SPOT" ]; then
+        _dryrun=$(aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" --dry-run 2>&1)
+    else
+        _dryrun=$(aws ec2 stop-instances --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" --dry-run 2>&1)
+    fi
+    if echo "${_dryrun}" | grep -qi "UnauthorizedOperation"; then
+        echo "[ $(date) ] AWS permission check failed — aborting broadcast: ${_dryrun}" | tee -a /root/gpumon_persistent.log
+        exit 1
+    fi
+
     wall "[ $(date) ] ${wall_message}"
     sleep 180
     wall "[ $(date) ] 3 minutes passed — shutting down now. Bye!"
@@ -251,6 +264,10 @@ else
         res=$(aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" 2>&1)
     else
         res=$(aws ec2 stop-instances --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" 2>&1)
+    fi
+    if echo "${res}" | grep -qi "error\|Exception"; then
+        echo "[ $(date) ] AWS shutdown call failed: ${res}" | tee -a /root/gpumon_persistent.log
+        exit 1
     fi
     echo "[ $(date) ] AWS result: ${res}"
 fi

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -97,9 +97,9 @@ secret_json=$(aws secretsmanager get-secret-value \
 if [ -z "${secret_json}" ] || [ "${secret_json}" = "None" ]; then
     echo "[ $(date) ] Warning: could not get creds from SM, using instance role: $(aws sts get-caller-identity 2>/dev/null)"
 elif command -v jq &>/dev/null; then
-    export AWS_ACCESS_KEY_ID=$(echo "${secret_json}" | jq -r '.AccessKeyId // empty')
-    export AWS_SECRET_ACCESS_KEY=$(echo "${secret_json}" | jq -r '.SecretAccessKey // empty')
-    export AWS_SESSION_TOKEN=$(echo "${secret_json}" | jq -r '.SessionToken // empty')
+    export AWS_ACCESS_KEY_ID=$(echo "${secret_json}" | jq -r '.AccessKeyId // empty' 2>/dev/null)
+    export AWS_SECRET_ACCESS_KEY=$(echo "${secret_json}" | jq -r '.SecretAccessKey // empty' 2>/dev/null)
+    export AWS_SESSION_TOKEN=$(echo "${secret_json}" | jq -r '.SessionToken // empty' 2>/dev/null)
     if [ -z "${AWS_ACCESS_KEY_ID}" ]; then
         echo "[ $(date) ] Warning: SM secret parsed but AccessKeyId not found — using instance role"
         unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -43,17 +43,20 @@ case "$POLICY" in
     SPOT|SEVERE)
         WINDOW_SECONDS=$((15 * 60))
         KILL_HALT_BACKOFF=$((30 * 60))
+        MIN_UPTIME_SECS=0
         ;;
     STANDARD)
         WINDOW_SECONDS=$((60 * 60))
         KILL_HALT_BACKOFF=$((2 * 60 * 60))
+        MIN_UPTIME_SECS=$((2 * 60 * 60))
         ;;
     *)
         WINDOW_SECONDS=$((2 * 60 * 60))
         KILL_HALT_BACKOFF=$((2 * 60 * 60))
+        MIN_UPTIME_SECS=0
         ;;
 esac
-echo "[ $(date) ] Instance: ${INSTANCE_ID}  Policy: ${POLICY}  Window: ${WINDOW_SECONDS}s  KillHaltBackoff: ${KILL_HALT_BACKOFF}s"
+echo "[ $(date) ] Instance: ${INSTANCE_ID}  Policy: ${POLICY}  Window: ${WINDOW_SECONDS}s  KillHaltBackoff: ${KILL_HALT_BACKOFF}s  MinUptime: ${MIN_UPTIME_SECS}s"
 
 # ── kill-halt backoff check ───────────────────────────────────────────────────
 TIMESTAMP_FILE="/tmp/timestamp.txt"
@@ -71,6 +74,20 @@ else
     else
         remaining=$((KILL_HALT_BACKOFF - time_diff))
         echo "[ $(date) ] Kill-halt active (${POLICY}: ${KILL_HALT_BACKOFF}s). ${remaining}s remaining. Will not halt now."
+        exit 1
+    fi
+fi
+
+# ── Boot-time uptime guard ────────────────────────────────────────────────────
+# Guarantees a minimum on-time after boot regardless of idle state.
+# Separate from kill_halt (user-triggered); this fires automatically.
+# restart_backoff=0 in mon_utils.py lets the pilot track real idleness from
+# boot so that idle time logged during boot counts toward the halt window.
+if [ "${MIN_UPTIME_SECS}" -gt 0 ]; then
+    uptime_secs=$(awk '{print int($1)}' /proc/uptime)
+    if [ "${uptime_secs}" -lt "${MIN_UPTIME_SECS}" ]; then
+        remaining=$((MIN_UPTIME_SECS - uptime_secs))
+        echo "[ $(date) ] Boot guard active (${POLICY}: uptime=${uptime_secs}s < ${MIN_UPTIME_SECS}s). ${remaining}s remaining. Will not halt now."
         exit 1
     fi
 fi

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -1,31 +1,12 @@
 #!/bin/bash
-# Parse gpumon logs; if Alarm_Pilot was "1" for the last 2 hours, stop/terminate
+# Parse gpumon logs; if Alarm_Pilot was "1" for the idle window, stop/terminate
 # the instance.  Intended to run as a cron job every 10 minutes.
 # (c) Paul Seifer, Autobrains LTD
 #
 # Example cron entry:
 #   */10 * * * * bash /root/gpumon/halt_it.sh | tee -a /tmp/halt_it_log.txt
 
-TIMESTAMP_FILE="/tmp/timestamp.txt"
-if [ ! -f "${TIMESTAMP_FILE}" ]; then
-    echo "[ $(date) ] Stop file not found, will continue the script"
-else
-    current_time=$(date +%s)
-    _timestamp=$(cat "${TIMESTAMP_FILE}")
-    timestamp=$(date -d "${_timestamp}" +%s)
-    time_diff=$((current_time - timestamp))
-    two_hours=$((2 * 60 * 60))
-
-    if [ "$time_diff" -ge "$two_hours" ]; then
-        echo "[ $(date) ] More than 2 hours have passed since the timestamp."
-        rm -f "${TIMESTAMP_FILE}" 2>/dev/null
-    else
-        remaining=$((two_hours - time_diff))
-        echo "[ $(date) ] Less than 2 hours have passed. $remaining seconds remaining. Will not halt now."
-        exit 1
-    fi
-fi
-
+# ── IMDS + identity ───────────────────────────────────────────────────────────
 # Always fetch fresh — IMDS calls are fast (<5 ms on EC2) and caching caused
 # stale-DTYPE bugs after instance type changes and stale INSTANCE_ID after AMI cloning.
 TOKEN=$(curl -s --max-time 5 -X PUT "http://169.254.169.254/latest/api/token" \
@@ -34,6 +15,11 @@ AWSREGION=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
     http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null)
 INSTANCE_ID=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
     http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
+
+if [[ -z "$AWSREGION" ]] || [[ "${INSTANCE_ID}" == "" ]] || [[ "$(echo "${INSTANCE_ID}" | grep -E 'i-[a-f0-9]{8,17}')" == "" ]]; then
+    echo "[ $(date) ] IMDS unreachable or returned bad values (INSTANCE_ID='${INSTANCE_ID}' AWSREGION='${AWSREGION}'), exiting"
+    exit 1
+fi
 
 if nvidia-smi --list-gpus >/dev/null 2>&1; then
     DTYPE=$(nvidia-smi --list-gpus | wc -l)
@@ -50,9 +36,39 @@ if [ -z "${POLICY}" ] || [ "${POLICY}" = "None" ]; then
     POLICY="STANDARD"
 fi
 
-if [[ -z "$AWSREGION" ]] || [[ "${INSTANCE_ID}" == "" ]] || [[ "$(echo "${INSTANCE_ID}" | grep -E 'i-[a-f0-9]{8,17}')" == "" ]]; then
-    echo "[ $(date) ] IMDS unreachable or returned bad values (INSTANCE_ID='${INSTANCE_ID}' AWSREGION='${AWSREGION}'), exiting"
-    exit 1
+# ── Policy-derived durations ──────────────────────────────────────────────────
+# SPOT/SEVERE have a 15-min idle window; their kill-halt backoff is 2x that.
+# All other policies use a 2-hour idle window with a matching 2-hour backoff.
+case "$POLICY" in
+    SPOT|SEVERE)
+        WINDOW_SECONDS=$((15 * 60))
+        KILL_HALT_BACKOFF=$((30 * 60))
+        ;;
+    *)
+        WINDOW_SECONDS=$((2 * 60 * 60))
+        KILL_HALT_BACKOFF=$((2 * 60 * 60))
+        ;;
+esac
+echo "[ $(date) ] Instance: ${INSTANCE_ID}  Policy: ${POLICY}  Window: ${WINDOW_SECONDS}s  KillHaltBackoff: ${KILL_HALT_BACKOFF}s"
+
+# ── kill-halt backoff check ───────────────────────────────────────────────────
+TIMESTAMP_FILE="/tmp/timestamp.txt"
+if [ ! -f "${TIMESTAMP_FILE}" ]; then
+    echo "[ $(date) ] No kill-halt backoff active, continuing"
+else
+    current_time=$(date +%s)
+    _timestamp=$(cat "${TIMESTAMP_FILE}")
+    timestamp=$(date -d "${_timestamp}" +%s)
+    time_diff=$((current_time - timestamp))
+
+    if [ "$time_diff" -ge "$KILL_HALT_BACKOFF" ]; then
+        echo "[ $(date) ] Kill-halt backoff expired (${time_diff}s >= ${KILL_HALT_BACKOFF}s) — resuming"
+        rm -f "${TIMESTAMP_FILE}" 2>/dev/null
+    else
+        remaining=$((KILL_HALT_BACKOFF - time_diff))
+        echo "[ $(date) ] Kill-halt active (${POLICY}: ${KILL_HALT_BACKOFF}s). ${remaining}s remaining. Will not halt now."
+        exit 1
+    fi
 fi
 
 if [[ -z "$DTYPE" || "$DTYPE" == "0" ]]; then
@@ -60,13 +76,6 @@ if [[ -z "$DTYPE" || "$DTYPE" == "0" ]]; then
 else
     FILE="GPU_TEMP_"
 fi
-
-# Time-based idle window — SPOT/SEVERE get 15 min; everything else 2 h
-case "$POLICY" in
-    SPOT|SEVERE) WINDOW_SECONDS=$((15 * 60)) ;;
-    *)           WINDOW_SECONDS=$((2 * 60 * 60)) ;;
-esac
-echo "[ $(date) ] Instance: ${INSTANCE_ID}  Policy: ${POLICY}  Window: ${WINDOW_SECONDS}s"
 
 # ── AWS CLI health check ──────────────────────────────────────────────────────
 echo "[ $(date) ] Checking AWS CLI..."
@@ -112,15 +121,27 @@ fi
 
 NOGO="TRUE"
 REASON="NO_REASON"
+
+# Policy-specific wall message strings
+case "$POLICY" in
+    SPOT|SEVERE)
+        _idle_str="15 minutes"
+        _pause_str="30 minutes"
+        ;;
+    *)
+        _idle_str="2 hours"
+        _pause_str="2 hours"
+        ;;
+esac
 wall_message="
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-This instance:${INSTANCE_ID} seems to have been idle for the last
-2 hours, will shut it down in 3 minutes from now. If you just logged in,
+This instance:${INSTANCE_ID} (${POLICY}) seems to have been idle for the last
+${_idle_str}, will shut it down in 3 minutes from now. If you just logged in,
 please wait a couple of minutes and restart it from the AWS console, or type:
 
     sudo bash /root/gpumon/kill_halt.sh
 
-to stop the shutdown now. The shutdown pause will last 2 hours.
+to stop the shutdown now. The shutdown pause will last ${_pause_str}.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
 # ── Collect log lines within the idle window ──────────────────────────────────

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
-#This script parses gpumon logs and if it finds out that Alarm_Pilot was 
-#present ONLY with value "1" for last 2 hours it will shut down the instance it runs on, 
-#it is intended to be run as cronjob every 10 minutes. (c)Paul Seifer, Autobrains LTD
-# something like: */10 * * * * bash /root/gpumon/halt_it.sh | tee -a /tmp/halt_it_log.txt
+# Parse gpumon logs; if Alarm_Pilot was "1" for the last 2 hours, stop/terminate
+# the instance.  Intended to run as a cron job every 10 minutes.
+# (c) Paul Seifer, Autobrains LTD
+#
+# Example cron entry:
+#   */10 * * * * bash /root/gpumon/halt_it.sh | tee -a /tmp/halt_it_log.txt
+
 TIMESTAMP_FILE="/tmp/timestamp.txt"
 if [ ! -f "${TIMESTAMP_FILE}" ]; then
     echo "[ $(date) ] Stop file not found, will continue the script"
@@ -11,26 +14,26 @@ else
     _timestamp=$(cat "${TIMESTAMP_FILE}")
     timestamp=$(date -d "${_timestamp}" +%s)
     time_diff=$((current_time - timestamp))
-    two_hours=$((2 * 60 * 60))  # 2 hours in seconds
+    two_hours=$((2 * 60 * 60))
 
-    if [ $time_diff -ge $two_hours ]; then
+    if [ "$time_diff" -ge "$two_hours" ]; then
         echo "[ $(date) ] More than 2 hours have passed since the timestamp."
-        rm -f ${TIMESTAMP_FILE} 2>/dev/null
+        rm -f "${TIMESTAMP_FILE}" 2>/dev/null
     else
         remaining=$((two_hours - time_diff))
-        echo "[ $(date) ] Less than 2 hours have passed. $remaining seconds remaining. will not halt the server now"
+        echo "[ $(date) ] Less than 2 hours have passed. $remaining seconds remaining. Will not halt now."
         exit 1
     fi
 fi
+
 HALT_FILE=/tmp/halt_it.info
 
-# Function to populate vars from IMDS + EC2 tags
 fetch_metadata() {
-    TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+    TOKEN=$(curl -s --max-time 5 -X PUT "http://169.254.169.254/latest/api/token" \
         -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
-    AWSREGION=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+    AWSREGION=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
         http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null)
-    INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+    INSTANCE_ID=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
         http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
     POLICY=$(aws ec2 describe-tags \
         --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=GPUMON_POLICY" \
@@ -58,7 +61,7 @@ else
     POLICY=$(grep "^POLICY=" "$HALT_FILE" | cut -d= -f2)
 fi
 
-# If any value is empty, the cached file is bad — drop it and refetch
+# If any value is empty the cached file is bad — drop it and refetch
 if [ -z "$INSTANCE_ID" ] || [ -z "$DTYPE" ] || [ -z "$AWSREGION" ] || [ -z "$POLICY" ]; then
     rm -f "$HALT_FILE"
     fetch_metadata
@@ -70,10 +73,11 @@ if [ -z "$INSTANCE_ID" ] || [ -z "$DTYPE" ] || [ -z "$AWSREGION" ] || [ -z "$POL
     } > "$HALT_FILE"
 fi
 
-if [[ "${INSTANCE_ID}" == "" ]] || [[ "$(echo ${INSTANCE_ID} | grep -E 'i-[a-f0-9]{8,17}')" == "" ]]; then
-        echo "[ $(date) ] Need INSTANCE_ID, like: i-02cb1c2e2dececfcd, exiting"
-        exit 1
+if [[ "${INSTANCE_ID}" == "" ]] || [[ "$(echo "${INSTANCE_ID}" | grep -E 'i-[a-f0-9]{8,17}')" == "" ]]; then
+    echo "[ $(date) ] Need INSTANCE_ID like i-02cb1c2e2dececfcd, exiting"
+    exit 1
 fi
+
 if [[ -z "$DTYPE" || "$DTYPE" == "0" ]]; then
     SEP=6
     FILE="CPUMON_LOGS_"
@@ -82,13 +86,12 @@ else
     SEP=12
     FILE="GPU_TEMP_"
     if [ "$DTYPE" -lt 4 ]; then
-        DEFAULT_STEP=500    # single GPU = 1 line/log, 500 lines ≈ 2h
+        DEFAULT_STEP=500
     else
-        DEFAULT_STEP=2000   # 4 GPUs = 4 lines/log
+        DEFAULT_STEP=2000
     fi
 fi
 
-# Aggressive-idle policies: 15 minutes regardless of GPU/CPU
 case "$POLICY" in
     SPOT|SEVERE)
         STEP=90
@@ -97,112 +100,96 @@ case "$POLICY" in
         STEP=$DEFAULT_STEP
         ;;
 esac
-echo "[ $(date) ] The instance:${INSTANCE_ID} Tag is:${POLICY} and the STEP therefore is:${STEP}"
-echo "[ $(date) ] Is AWS cli installed?"
-check=$(aws s3 ls 2>&1 | grep "snap")
-if [ "${check}" != "" ]; then
-   echo "[ $(date) ] need to fix, will run: apt install awscli"
-   DEBIAN_FRONTEND=noninteractive apt install -y awscli
-   echo "[ $(date) ] done fixin"
- else
-   echo "[ $(date) ] no problem with awscli...continue..."
+echo "[ $(date) ] Instance: ${INSTANCE_ID}  Policy: ${POLICY}  Step: ${STEP}"
+
+# ── AWS CLI health check ──────────────────────────────────────────────────────
+echo "[ $(date) ] Checking AWS CLI..."
+if ! timeout 30 aws sts get-caller-identity --region "${AWSREGION}" &>/dev/null; then
+    echo "[ $(date) ] AWS CLI not working, attempting reinstall..."
+    DEBIAN_FRONTEND=noninteractive timeout 120 apt install -y awscli || \
+        timeout 120 python3 -m pip install --upgrade awscli boto3 botocore || true
 fi
-echo "[ $(date) ] Checking awscli validity"
-check=$(aws s3 ls 2>&1 | grep docevents | grep cannot);
-if [ "${check}" != "" ]; then
-   echo "[ $(date) ] need to fix, will run: python3 -m pip install --upgrade boto3 botocore awscli"
-   python3 -m pip install --upgrade boto3 botocore awscli
-   echo "[ $(date) ] done fixin"
- else
-   echo "[ $(date) ] no problem with awscli...continue..."
-fi
-check=$(sudo aws s3 ls 2>&1 | grep docevents | grep cannot);
-if [ "${check}" != "" ]; then
-   echo "[ $(date) ] need to fix, will run: sudo python3 -m pip install --upgrade boto3 botocore awscli"
-   sudo python3 -m pip install --upgrade boto3 botocore awscli --break-system-packages
-   echo "[ $(date) ] done fixin"
- else
-   echo "[ $(date) ] no problem with sudo awscli...continue..."
-fi
-echo "[ $(date) ] Getting creds from SM..."
-creds_tmp=$(aws secretsmanager get-secret-value --secret-id "AB/InstanceRole" --region eu-west-1 |grep SecretString | rev | cut -c2- | rev | cut -d ":" -f2- | tr -d " " | tr -d '"')
+
+# ── Credentials via Secrets Manager ──────────────────────────────────────────
+# The secret lives in a specific region (may differ from the instance region).
+# Override with GPUMON_SECRET_REGION / GPUMON_SECRET_ID env vars as needed.
+SECRET_ID="${GPUMON_SECRET_ID:-AB/InstanceRole}"
+SECRET_REGION="${GPUMON_SECRET_REGION:-eu-west-1}"
+echo "[ $(date) ] Getting creds from SM (secret: ${SECRET_ID} region: ${SECRET_REGION})..."
+creds_tmp=$(aws secretsmanager get-secret-value \
+    --secret-id "${SECRET_ID}" \
+    --region "${SECRET_REGION}" \
+    2>/dev/null \
+    | grep SecretString | rev | cut -c2- | rev | cut -d ":" -f2- | tr -d " " | tr -d '"')
 if [ "${creds_tmp}" == "" ]; then
-        echo "[ $(date) ] Warning, could not get creds from SM, will use whatever Role current user has:$(aws sts get-caller-identity)"
+    echo "[ $(date) ] Warning: could not get creds from SM, using instance role: $(aws sts get-caller-identity 2>/dev/null)"
 else
-        export AWS_ACCESS_KEY_ID=$(echo "${creds_tmp}" | cut -d ":" -f1)
-        export AWS_SECRET_ACCESS_KEY=$(echo "${creds_tmp}" | cut -d ":" -f2-)
+    export AWS_ACCESS_KEY_ID=$(echo "${creds_tmp}" | cut -d ":" -f1)
+    export AWS_SECRET_ACCESS_KEY=$(echo "${creds_tmp}" | cut -d ":" -f2-)
 fi
 
 NOGO="TRUE"
 REASON="NO_REASON"
-wall_message="""
+wall_message="
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-This instance:${INSTANCE_ID} seems to be have been idle for the last 
-2 hours, will shut it down in 3 minutes from now. If you have been 
-unfortunate to just logged in into it, please wait couple of minutes and 
-start it again from AWS console or script or type:
+This instance:${INSTANCE_ID} seems to have been idle for the last
+2 hours, will shut it down in 3 minutes from now. If you just logged in,
+please wait a couple of minutes and restart it from the AWS console, or type:
 
-sudo bash /root/gpumon/kill_halt.sh
+    sudo bash /root/gpumon/kill_halt.sh
 
-to stop the shutdown now. The shutdown pause in this case will last 2 hours
-after which the shutdown sequence will resume.
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-"""
-#lets check if we have TMP file
-filename=$(ls -lit /tmp/${FILE}* | head -1 | rev | cut -d " " -f1 | rev)
+to stop the shutdown now. The shutdown pause will last 2 hours.
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
+
+# ── Find latest log file ──────────────────────────────────────────────────────
+filename=$(ls -lit /tmp/${FILE}* 2>/dev/null | head -1 | rev | cut -d " " -f1 | rev)
 if [ "${filename}" == "" ]; then
     NOGO="TRUE"
-    REASON="LOG_NOT_FOUND:${filename}"
-  else
+    REASON="LOG_NOT_FOUND"
+else
     NOGO="FALSE"
-    if [ "$(cat ${filename} | wc -l)" -lt "${STEP}" ]; then
-       NOGO="TRUE"
-       REASON="LOG_EXISTS_BUT_NOT_ENOUGH_DATA_IN_IT_SO_FAR:($(cat ${filename} | wc -l))_LINES"
-    fi
-fi
-#Now lets check if we have correct output
-if [ "${NOGO}" == "FALSE" ]; then 
-    check=$(tail -${STEP} ${filename} | cut -d ":" -f$SEP | sort | uniq -c | grep "CPU_Util")
-    if [ "${check}" == "" ]; then
-       NOGO="TRUE"
-       REASON="LOG_FILE_EXISTS_BUT_NO_VALID_DATA:${check}"
-    else
-    #we got data, now lets analyse it
-      result=$(tail -${STEP} ${filename} | cut -d ":" -f$SEP | sort | uniq -c | grep "0,CPU_Util_Tripped")
-      if [ "${result}" == "" ]; then
-          #looks like there is data but only indication that Alarm was on for last two hours, lets make sure
-          positive=$(tail -${STEP} ${filename} | cut -d ":" -f$SEP | sort | uniq -c | grep "1,CPU_Util_Tripped")
-          if [ "${positive}" == "" ]; then
-              NOGO="TRUE"
-              REASON="ALARM_WASNT_ON_DURING_LAST_2_HOURS,INCONCLUSIVE,DEBUG:${positive} result:${result}"
-              #this shouldnt happen, if we get this message in logs something is very wrong
-          else
-              NOGO="FALSE"
-              REASON="WE_GOT_PILOT_ONLY_FOR_2_HOURS_ITS_A_GO:${positive} result:${result}"
-              #this means there was good amount of data and not a single line of Alarm=0 in it, we should turn the instance off
-          fi
-      else
+    if [ "$(wc -l < "${filename}")" -lt "${STEP}" ]; then
         NOGO="TRUE"
-        REASON="DATA_IS_OK_BUT_GOT_ACTIVITY_SPIKE:${check}"
-        #This is normal - at least a single Alarm=0 in last two hours = not turning instance off
-      fi
+        REASON="LOG_EXISTS_BUT_NOT_ENOUGH_DATA_IN_IT_SO_FAR:($(wc -l < "${filename}"))_LINES"
     fi
 fi
 
-#main if
+# ── Analyse log ───────────────────────────────────────────────────────────────
+if [ "${NOGO}" == "FALSE" ]; then
+    check=$(tail -"${STEP}" "${filename}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "CPU_Util")
+    if [ "${check}" == "" ]; then
+        NOGO="TRUE"
+        REASON="LOG_FILE_EXISTS_BUT_NO_VALID_DATA:${check}"
+    else
+        result=$(tail -"${STEP}" "${filename}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "0,CPU_Util_Tripped")
+        if [ "${result}" == "" ]; then
+            positive=$(tail -"${STEP}" "${filename}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "1,CPU_Util_Tripped")
+            if [ "${positive}" == "" ]; then
+                NOGO="TRUE"
+                REASON="ALARM_WASNT_ON_DURING_LAST_2_HOURS,INCONCLUSIVE,DEBUG:${positive} result:${result}"
+            else
+                NOGO="FALSE"
+                REASON="WE_GOT_PILOT_ONLY_FOR_2_HOURS_ITS_A_GO:${positive} result:${result}"
+            fi
+        else
+            NOGO="TRUE"
+            REASON="DATA_IS_OK_BUT_GOT_ACTIVITY_SPIKE:${check}"
+        fi
+    fi
+fi
+
+# ── Shutdown decision ─────────────────────────────────────────────────────────
 if [ "${NOGO}" == "TRUE" ]; then
-   echo "[ $(date) ] WE ARE A NO-GO, BECAUSE:${REASON} TILL LATER, TA TA"
-   #res=$(sudo aws ec2 describe-instances --instance-ids "${INSTANCE_ID}" --region $AWSREGION)
-   #echo "[ $(date) ] debug: got result for aws describe-instances: ${res}"
+    echo "[ $(date) ] NO-GO: ${REASON}"
 else
-   echo "[ $(date) ] LOOKS LIKE WE ARE A GO - WILL SHUT THE INSTANCE DOWN, REASON:${REASON}" | tee -a /root/gpumon_persistent.log
-   wall "[ $(date) ] ${wall_message}"
-   sleep 180
-   wall "[ $(date) ] Well, 3 minutes have passed, shutdown is now...Bye Bye"
-   if [ "${POLICY}" == "SPOT" ]; then
-      res=$(sudo aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" --region $AWSREGION 2>&1) #in SPOTs we terminate instead of shutdown
-   else
-      res=$(sudo aws ec2 stop-instances --instance-ids "${INSTANCE_ID}" --region $AWSREGION 2>&1)
-   fi
-   echo "[ $(date) ] debug: got result for aws stop-instances: ${res}"
+    echo "[ $(date) ] GO — shutting down. Reason: ${REASON}" | tee -a /root/gpumon_persistent.log
+    wall "[ $(date) ] ${wall_message}"
+    sleep 180
+    wall "[ $(date) ] 3 minutes passed — shutting down now. Bye!"
+    if [ "${POLICY}" == "SPOT" ]; then
+        res=$(aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" 2>&1)
+    else
+        res=$(aws ec2 stop-instances --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" 2>&1)
+    fi
+    echo "[ $(date) ] AWS result: ${res}"
 fi

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -36,6 +36,14 @@ if [ -z "${POLICY}" ] || [ "${POLICY}" = "None" ]; then
     POLICY="STANDARD"
 fi
 
+# Project tag — fetched fresh; used to select ASG-aware termination for SPOT
+PROJECT=$(aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=${INSTANCE_ID}" "Name=key,Values=Project" \
+    --query "Tags[0].Value" --output text --region "${AWSREGION}" 2>/dev/null)
+if [ -z "${PROJECT}" ] || [ "${PROJECT}" = "None" ]; then
+    PROJECT=""
+fi
+
 # ── Policy-derived durations ──────────────────────────────────────────────────
 # SPOT/SEVERE have a 15-min idle window; their kill-halt backoff is 2x that.
 # All other policies use a 2-hour idle window with a matching 2-hour backoff.
@@ -56,7 +64,7 @@ case "$POLICY" in
         MIN_UPTIME_SECS=0
         ;;
 esac
-echo "[ $(date) ] Instance: ${INSTANCE_ID}  Policy: ${POLICY}  Window: ${WINDOW_SECONDS}s  KillHaltBackoff: ${KILL_HALT_BACKOFF}s  MinUptime: ${MIN_UPTIME_SECS}s"
+echo "[ $(date) ] Instance: ${INSTANCE_ID}  Policy: ${POLICY}  Project: ${PROJECT:-none}  Window: ${WINDOW_SECONDS}s  KillHaltBackoff: ${KILL_HALT_BACKOFF}s  MinUptime: ${MIN_UPTIME_SECS}s"
 
 # ── kill-halt backoff check ───────────────────────────────────────────────────
 TIMESTAMP_FILE="/tmp/timestamp.txt"
@@ -248,21 +256,39 @@ else
     echo "[ $(date) ] GO — shutting down. Reason: ${REASON}" | tee -a /root/gpumon_persistent.log
 
     # Dry-run before broadcasting — prevents wall-message spam when creds lack permission.
-    # DryRunOperation = authorized; UnauthorizedOperation = not authorized.
-    if [ "${POLICY}" == "SPOT" ]; then
+    # FH-PIPELINE SPOT instances live in an ASG; use describe-auto-scaling-instances as a
+    # permission probe (ASG terminate has no --dry-run flag). For all other cases use the
+    # standard EC2 --dry-run: DryRunOperation = authorized, UnauthorizedOperation = denied.
+    if [ "${POLICY}" == "SPOT" ] && [ "${PROJECT}" == "FH-PIPELINE" ]; then
+        _dryrun=$(aws autoscaling describe-auto-scaling-instances \
+            --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" 2>&1)
+        if echo "${_dryrun}" | grep -qi "error\|AccessDenied\|AuthFailure"; then
+            echo "[ $(date) ] ASG permission check failed — aborting broadcast: ${_dryrun}" | tee -a /root/gpumon_persistent.log
+            exit 1
+        fi
+    elif [ "${POLICY}" == "SPOT" ]; then
         _dryrun=$(aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" --dry-run 2>&1)
+        if echo "${_dryrun}" | grep -qi "UnauthorizedOperation"; then
+            echo "[ $(date) ] AWS permission check failed — aborting broadcast: ${_dryrun}" | tee -a /root/gpumon_persistent.log
+            exit 1
+        fi
     else
         _dryrun=$(aws ec2 stop-instances --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" --dry-run 2>&1)
-    fi
-    if echo "${_dryrun}" | grep -qi "UnauthorizedOperation"; then
-        echo "[ $(date) ] AWS permission check failed — aborting broadcast: ${_dryrun}" | tee -a /root/gpumon_persistent.log
-        exit 1
+        if echo "${_dryrun}" | grep -qi "UnauthorizedOperation"; then
+            echo "[ $(date) ] AWS permission check failed — aborting broadcast: ${_dryrun}" | tee -a /root/gpumon_persistent.log
+            exit 1
+        fi
     fi
 
     wall "[ $(date) ] ${wall_message}"
     sleep 180
     wall "[ $(date) ] 3 minutes passed — shutting down now. Bye!"
-    if [ "${POLICY}" == "SPOT" ]; then
+    if [ "${POLICY}" == "SPOT" ] && [ "${PROJECT}" == "FH-PIPELINE" ]; then
+        res=$(aws autoscaling terminate-instance-in-auto-scaling-group \
+            --instance-id "${INSTANCE_ID}" \
+            --should-decrement-desired-capacity \
+            --region "${AWSREGION}" 2>&1)
+    elif [ "${POLICY}" == "SPOT" ]; then
         res=$(aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" 2>&1)
     else
         res=$(aws ec2 stop-instances --instance-ids "${INSTANCE_ID}" --region "${AWSREGION}" 2>&1)

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -84,26 +84,17 @@ fi
 if [[ -z "$DTYPE" || "$DTYPE" == "0" ]]; then
     SEP=6
     FILE="CPUMON_LOGS_"
-    DEFAULT_STEP=500
 else
     SEP=12
     FILE="GPU_TEMP_"
-    if [ "$DTYPE" -lt 4 ]; then
-        DEFAULT_STEP=500
-    else
-        DEFAULT_STEP=2000
-    fi
 fi
 
+# Time-based idle window — SPOT/SEVERE get 15 min; everything else 2 h
 case "$POLICY" in
-    SPOT|SEVERE)
-        STEP=90
-        ;;
-    *)
-        STEP=$DEFAULT_STEP
-        ;;
+    SPOT|SEVERE) WINDOW_SECONDS=$((15 * 60)) ;;
+    *)           WINDOW_SECONDS=$((2 * 60 * 60)) ;;
 esac
-echo "[ $(date) ] Instance: ${INSTANCE_ID}  Policy: ${POLICY}  Step: ${STEP}"
+echo "[ $(date) ] Instance: ${INSTANCE_ID}  Policy: ${POLICY}  Window: ${WINDOW_SECONDS}s"
 
 # ── AWS CLI health check ──────────────────────────────────────────────────────
 echo "[ $(date) ] Checking AWS CLI..."
@@ -160,39 +151,69 @@ please wait a couple of minutes and restart it from the AWS console, or type:
 to stop the shutdown now. The shutdown pause will last 2 hours.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 
-# ── Find latest log file ──────────────────────────────────────────────────────
-filename=$(ls -lit /tmp/${FILE}* 2>/dev/null | head -1 | rev | cut -d " " -f1 | rev)
-if [ "${filename}" == "" ]; then
-    NOGO="TRUE"
-    REASON="LOG_NOT_FOUND"
-else
-    NOGO="FALSE"
-    if [ "$(wc -l < "${filename}")" -lt "${STEP}" ]; then
-        NOGO="TRUE"
-        REASON="LOG_EXISTS_BUT_NOT_ENOUGH_DATA_IN_IT_SO_FAR:($(wc -l < "${filename}"))_LINES"
-    fi
-fi
+# ── Collect log lines within the idle window ──────────────────────────────────
+# Log files rotate hourly and are named <PREFIX>YYYY-MM-DDTHH.
+# Build the list of candidate files by stepping through each hour in the window,
+# then filter lines by the embedded ISO timestamp using awk string comparison
+# (ISO format is lexicographically ordered so >= works without date arithmetic).
+now=$(date +%s)
+cutoff=$((now - WINDOW_SECONDS))
+cutoff_str=$(date -d "@${cutoff}" +'%Y-%m-%d %H:%M:%S')
 
-# ── Analyse log ───────────────────────────────────────────────────────────────
-if [ "${NOGO}" == "FALSE" ]; then
-    check=$(tail -"${STEP}" "${filename}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "CPU_Util")
-    if [ "${check}" == "" ]; then
-        NOGO="TRUE"
-        REASON="LOG_FILE_EXISTS_BUT_NO_VALID_DATA:${check}"
+candidate_files=""
+t=$cutoff
+while [ "$t" -le "$((now + 3600))" ]; do
+    f="/tmp/${FILE}$(date -d @${t} +'%Y-%m-%dT%H')"
+    [ -f "$f" ] && candidate_files="${candidate_files} ${f}"
+    t=$((t + 3600))
+done
+
+if [ -z "${candidate_files}" ]; then
+    NOGO="TRUE"
+    REASON="NO_LOG_FILES_FOUND"
+else
+    # awk substr(line,3,19) extracts "YYYY-MM-DD HH:MM:SS" from "[ YYYY-MM-DD HH:MM:SS..."
+    # shellcheck disable=SC2086
+    window_lines=$(cat ${candidate_files} 2>/dev/null | awk -v cutoff="${cutoff_str}" '{
+        ts = substr($0, 3, 19)
+        if (ts >= cutoff) print
+    }')
+
+    line_count=$(echo "${window_lines}" | grep -c .)
+
+    # Require at least 50% of the expected sample count (1 line/10 s per GPU process,
+    # or 1 line/10 s for CPU-only).  Multi-GPU instances write DTYPE lines per tick.
+    if [ "${DTYPE}" -gt 0 ]; then
+        min_lines=$(( WINDOW_SECONDS / 20 * DTYPE ))
     else
-        result=$(tail -"${STEP}" "${filename}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "0,CPU_Util_Tripped")
-        if [ "${result}" == "" ]; then
-            positive=$(tail -"${STEP}" "${filename}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "1,CPU_Util_Tripped")
-            if [ "${positive}" == "" ]; then
-                NOGO="TRUE"
-                REASON="ALARM_WASNT_ON_DURING_LAST_2_HOURS,INCONCLUSIVE,DEBUG:${positive} result:${result}"
-            else
-                NOGO="FALSE"
-                REASON="WE_GOT_PILOT_ONLY_FOR_2_HOURS_ITS_A_GO:${positive} result:${result}"
-            fi
-        else
+        min_lines=$(( WINDOW_SECONDS / 20 ))
+    fi
+    echo "[ $(date) ] Lines in window: ${line_count}  min required: ${min_lines}"
+
+    if [ "${line_count}" -lt "${min_lines}" ]; then
+        NOGO="TRUE"
+        REASON="INSUFFICIENT_DATA:${line_count}_lines_in_${WINDOW_SECONDS}s_window_(need_${min_lines})"
+    else
+        # ── Analyse window lines ───────────────────────────────────────────────
+        check=$(echo "${window_lines}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "CPU_Util")
+        if [ "${check}" == "" ]; then
             NOGO="TRUE"
-            REASON="DATA_IS_OK_BUT_GOT_ACTIVITY_SPIKE:${check}"
+            REASON="LOG_EXISTS_BUT_NO_VALID_DATA"
+        else
+            result=$(echo "${window_lines}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "0,CPU_Util_Tripped")
+            if [ "${result}" == "" ]; then
+                positive=$(echo "${window_lines}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "1,CPU_Util_Tripped")
+                if [ "${positive}" == "" ]; then
+                    NOGO="TRUE"
+                    REASON="ALARM_WASNT_ON_DURING_WINDOW,INCONCLUSIVE"
+                else
+                    NOGO="FALSE"
+                    REASON="PILOT_ON_FOR_FULL_${WINDOW_SECONDS}s_WINDOW:${positive}"
+                fi
+            else
+                NOGO="TRUE"
+                REASON="ACTIVITY_SPIKE_IN_WINDOW:${result}"
+            fi
         fi
     fi
 fi

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -181,12 +181,14 @@ else
 
     line_count=$(echo "${window_lines}" | grep -c .)
 
-    # Require at least 50% of the expected sample count (1 line/10 s per GPU process,
-    # or 1 line/10 s for CPU-only).  Multi-GPU instances write DTYPE lines per tick.
+    # Require 90% of expected samples so the full window is covered.
+    # At 10 s/sample, 90% of WINDOW_SECONDS = WINDOW_SECONDS * 9 / 100.
+    # Multi-GPU instances write DTYPE lines per tick so multiply accordingly.
+    # This prevents a 1-h-idle / 1-h-active pattern from passing the 2-h check.
     if [ "${DTYPE}" -gt 0 ]; then
-        min_lines=$(( WINDOW_SECONDS / 20 * DTYPE ))
+        min_lines=$(( WINDOW_SECONDS * 9 / 100 * DTYPE ))
     else
-        min_lines=$(( WINDOW_SECONDS / 20 ))
+        min_lines=$(( WINDOW_SECONDS * 9 / 100 ))
     fi
     echo "[ $(date) ] Lines in window: ${line_count}  min required: ${min_lines}"
 

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -102,8 +102,10 @@ fi
 echo "[ $(date) ] Checking AWS CLI..."
 if ! timeout 30 aws sts get-caller-identity --region "${AWSREGION}" &>/dev/null; then
     echo "[ $(date) ] AWS CLI not working, attempting reinstall..."
-    DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y awscli || \
-        timeout 120 python3 -m pip install --upgrade awscli boto3 botocore || true
+    DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 update -q && \
+        apt-get -o DPkg::Lock::Timeout=120 install -y awscli || \
+        timeout 120 python3 -m pip install --break-system-packages --upgrade awscli boto3 botocore || \
+        snap install aws-cli --classic 2>/dev/null || true
 fi
 
 # ── Credentials via Secrets Manager ──────────────────────────────────────────

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -56,10 +56,8 @@ if [[ -z "$AWSREGION" ]] || [[ "${INSTANCE_ID}" == "" ]] || [[ "$(echo "${INSTAN
 fi
 
 if [[ -z "$DTYPE" || "$DTYPE" == "0" ]]; then
-    SEP=6
     FILE="CPUMON_LOGS_"
 else
-    SEP=12
     FILE="GPU_TEMP_"
 fi
 
@@ -171,24 +169,25 @@ else
         REASON="INSUFFICIENT_DATA:${line_count}_lines_in_${WINDOW_SECONDS}s_window_(need_${min_lines})"
     else
         # ── Analyse window lines ───────────────────────────────────────────────
-        check=$(echo "${window_lines}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "CPU_Util")
-        if [ "${check}" == "" ]; then
+        # Match Alarm_Pilot_value by name rather than by colon-delimited field
+        # position — positional cut breaks when tag values (Team, Employee, etc.)
+        # contain colons, which shifts every subsequent field index.
+        valid_count=$(echo "${window_lines}" | grep -cE 'Alarm_Pilot_value:[01],' || true)
+        if [ "${valid_count}" -eq 0 ]; then
             NOGO="TRUE"
             REASON="LOG_EXISTS_BUT_NO_VALID_DATA"
         else
-            result=$(echo "${window_lines}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "0,CPU_Util_Tripped")
-            if [ "${result}" == "" ]; then
-                positive=$(echo "${window_lines}" | cut -d ":" -f"${SEP}" | sort | uniq -c | grep "1,CPU_Util_Tripped")
-                if [ "${positive}" == "" ]; then
-                    NOGO="TRUE"
-                    REASON="ALARM_WASNT_ON_DURING_WINDOW,INCONCLUSIVE"
-                else
-                    NOGO="FALSE"
-                    REASON="PILOT_ON_FOR_FULL_${WINDOW_SECONDS}s_WINDOW:${positive}"
-                fi
+            pilot_off=$(echo "${window_lines}" | grep -cE 'Alarm_Pilot_value:0,' || true)
+            pilot_on=$(echo "${window_lines}"  | grep -cE 'Alarm_Pilot_value:1,' || true)
+            if [ "${pilot_off}" -gt 0 ]; then
+                NOGO="TRUE"
+                REASON="ACTIVITY_SPIKE_IN_WINDOW:${pilot_off}_lines_pilot_off"
+            elif [ "${pilot_on}" -gt 0 ]; then
+                NOGO="FALSE"
+                REASON="PILOT_ON_FOR_FULL_${WINDOW_SECONDS}s_WINDOW:${pilot_on}_lines"
             else
                 NOGO="TRUE"
-                REASON="ACTIVITY_SPIKE_IN_WINDOW:${result}"
+                REASON="ALARM_WASNT_ON_DURING_WINDOW,INCONCLUSIVE"
             fi
         fi
     fi

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -35,9 +35,6 @@ fetch_metadata() {
         http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null)
     INSTANCE_ID=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
         http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
-    POLICY=$(aws ec2 describe-tags \
-        --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=GPUMON_POLICY" \
-        --query "Tags[0].Value" --output text --region "$AWSREGION")
 
     if nvidia-smi --list-gpus >/dev/null 2>&1; then
         DTYPE=$(nvidia-smi --list-gpus | wc -l)
@@ -52,25 +49,31 @@ if [ ! -s "$HALT_FILE" ]; then
         echo "INSTANCE_ID=${INSTANCE_ID}"
         echo "DTYPE=${DTYPE}"
         echo "AWSREGION=${AWSREGION}"
-        echo "POLICY=${POLICY}"
     } > "$HALT_FILE"
 else
     INSTANCE_ID=$(grep "^INSTANCE_ID=" "$HALT_FILE" | cut -d= -f2)
     DTYPE=$(grep "^DTYPE=" "$HALT_FILE" | cut -d= -f2)
     AWSREGION=$(grep "^AWSREGION=" "$HALT_FILE" | cut -d= -f2)
-    POLICY=$(grep "^POLICY=" "$HALT_FILE" | cut -d= -f2)
 fi
 
-# If any value is empty the cached file is bad — drop it and refetch
-if [ -z "$INSTANCE_ID" ] || [ -z "$DTYPE" ] || [ -z "$AWSREGION" ] || [ -z "$POLICY" ]; then
+# If any cached value is empty the file is bad — drop it and refetch
+if [ -z "$INSTANCE_ID" ] || [ -z "$DTYPE" ] || [ -z "$AWSREGION" ]; then
     rm -f "$HALT_FILE"
     fetch_metadata
     {
         echo "INSTANCE_ID=${INSTANCE_ID}"
         echo "DTYPE=${DTYPE}"
         echo "AWSREGION=${AWSREGION}"
-        echo "POLICY=${POLICY}"
     } > "$HALT_FILE"
+fi
+
+# POLICY is always fetched fresh so tag changes take effect on the next cron run
+POLICY=$(aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=${INSTANCE_ID}" "Name=key,Values=GPUMON_POLICY" \
+    --query "Tags[0].Value" --output text --region "${AWSREGION}" 2>/dev/null)
+# Treat missing/None tag as STANDARD
+if [ -z "${POLICY}" ] || [ "${POLICY}" = "None" ]; then
+    POLICY="STANDARD"
 fi
 
 if [[ "${INSTANCE_ID}" == "" ]] || [[ "$(echo "${INSTANCE_ID}" | grep -E 'i-[a-f0-9]{8,17}')" == "" ]]; then
@@ -116,16 +119,32 @@ fi
 SECRET_ID="${GPUMON_SECRET_ID:-AB/InstanceRole}"
 SECRET_REGION="${GPUMON_SECRET_REGION:-eu-west-1}"
 echo "[ $(date) ] Getting creds from SM (secret: ${SECRET_ID} region: ${SECRET_REGION})..."
-creds_tmp=$(aws secretsmanager get-secret-value \
+
+# Ensure jq is available for robust JSON parsing
+if ! command -v jq &>/dev/null; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y jq -q 2>/dev/null || true
+fi
+
+secret_json=$(aws secretsmanager get-secret-value \
     --secret-id "${SECRET_ID}" \
     --region "${SECRET_REGION}" \
-    2>/dev/null \
-    | grep SecretString | rev | cut -c2- | rev | cut -d ":" -f2- | tr -d " " | tr -d '"')
-if [ "${creds_tmp}" == "" ]; then
+    --query "SecretString" \
+    --output text 2>/dev/null)
+
+if [ -z "${secret_json}" ] || [ "${secret_json}" = "None" ]; then
     echo "[ $(date) ] Warning: could not get creds from SM, using instance role: $(aws sts get-caller-identity 2>/dev/null)"
+elif command -v jq &>/dev/null; then
+    export AWS_ACCESS_KEY_ID=$(echo "${secret_json}" | jq -r '.AccessKeyId // empty')
+    export AWS_SECRET_ACCESS_KEY=$(echo "${secret_json}" | jq -r '.SecretAccessKey // empty')
+    export AWS_SESSION_TOKEN=$(echo "${secret_json}" | jq -r '.SessionToken // empty')
+    if [ -z "${AWS_ACCESS_KEY_ID}" ]; then
+        echo "[ $(date) ] Warning: SM secret parsed but AccessKeyId not found — using instance role"
+        unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+    else
+        echo "[ $(date) ] SM credentials loaded"
+    fi
 else
-    export AWS_ACCESS_KEY_ID=$(echo "${creds_tmp}" | cut -d ":" -f1)
-    export AWS_SECRET_ACCESS_KEY=$(echo "${creds_tmp}" | cut -d ":" -f2-)
+    echo "[ $(date) ] jq unavailable — using instance role"
 fi
 
 NOGO="TRUE"

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -44,6 +44,10 @@ case "$POLICY" in
         WINDOW_SECONDS=$((15 * 60))
         KILL_HALT_BACKOFF=$((30 * 60))
         ;;
+    STANDARD)
+        WINDOW_SECONDS=$((60 * 60))
+        KILL_HALT_BACKOFF=$((2 * 60 * 60))
+        ;;
     *)
         WINDOW_SECONDS=$((2 * 60 * 60))
         KILL_HALT_BACKOFF=$((2 * 60 * 60))
@@ -127,6 +131,10 @@ case "$POLICY" in
     SPOT|SEVERE)
         _idle_str="15 minutes"
         _pause_str="30 minutes"
+        ;;
+    STANDARD)
+        _idle_str="1 hour"
+        _pause_str="2 hours"
         ;;
     *)
         _idle_str="2 hours"

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -100,7 +100,7 @@ echo "[ $(date) ] Instance: ${INSTANCE_ID}  Policy: ${POLICY}  Window: ${WINDOW_
 echo "[ $(date) ] Checking AWS CLI..."
 if ! timeout 30 aws sts get-caller-identity --region "${AWSREGION}" &>/dev/null; then
     echo "[ $(date) ] AWS CLI not working, attempting reinstall..."
-    DEBIAN_FRONTEND=noninteractive timeout 120 apt install -y awscli || \
+    DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y awscli || \
         timeout 120 python3 -m pip install --upgrade awscli boto3 botocore || true
 fi
 
@@ -113,7 +113,7 @@ echo "[ $(date) ] Getting creds from SM (secret: ${SECRET_ID} region: ${SECRET_R
 
 # Ensure jq is available for robust JSON parsing
 if ! command -v jq &>/dev/null; then
-    DEBIAN_FRONTEND=noninteractive apt-get install -y jq -q 2>/dev/null || true
+    DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y jq -q 2>/dev/null || true
 fi
 
 secret_json=$(aws secretsmanager get-secret-value \

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -26,45 +26,19 @@ else
     fi
 fi
 
-HALT_FILE=/tmp/halt_it.info
+# Always fetch fresh — IMDS calls are fast (<5 ms on EC2) and caching caused
+# stale-DTYPE bugs after instance type changes and stale INSTANCE_ID after AMI cloning.
+TOKEN=$(curl -s --max-time 5 -X PUT "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
+AWSREGION=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
+    http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null)
+INSTANCE_ID=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
+    http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
 
-fetch_metadata() {
-    TOKEN=$(curl -s --max-time 5 -X PUT "http://169.254.169.254/latest/api/token" \
-        -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
-    AWSREGION=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
-        http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null)
-    INSTANCE_ID=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
-        http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
-
-    if nvidia-smi --list-gpus >/dev/null 2>&1; then
-        DTYPE=$(nvidia-smi --list-gpus | wc -l)
-    else
-        DTYPE="0"
-    fi
-}
-
-if [ ! -s "$HALT_FILE" ]; then
-    fetch_metadata
-    {
-        echo "INSTANCE_ID=${INSTANCE_ID}"
-        echo "DTYPE=${DTYPE}"
-        echo "AWSREGION=${AWSREGION}"
-    } > "$HALT_FILE"
+if nvidia-smi --list-gpus >/dev/null 2>&1; then
+    DTYPE=$(nvidia-smi --list-gpus | wc -l)
 else
-    INSTANCE_ID=$(grep "^INSTANCE_ID=" "$HALT_FILE" | cut -d= -f2)
-    DTYPE=$(grep "^DTYPE=" "$HALT_FILE" | cut -d= -f2)
-    AWSREGION=$(grep "^AWSREGION=" "$HALT_FILE" | cut -d= -f2)
-fi
-
-# If any cached value is empty the file is bad — drop it and refetch
-if [ -z "$INSTANCE_ID" ] || [ -z "$DTYPE" ] || [ -z "$AWSREGION" ]; then
-    rm -f "$HALT_FILE"
-    fetch_metadata
-    {
-        echo "INSTANCE_ID=${INSTANCE_ID}"
-        echo "DTYPE=${DTYPE}"
-        echo "AWSREGION=${AWSREGION}"
-    } > "$HALT_FILE"
+    DTYPE="0"
 fi
 
 # POLICY is always fetched fresh so tag changes take effect on the next cron run
@@ -76,8 +50,8 @@ if [ -z "${POLICY}" ] || [ "${POLICY}" = "None" ]; then
     POLICY="STANDARD"
 fi
 
-if [[ "${INSTANCE_ID}" == "" ]] || [[ "$(echo "${INSTANCE_ID}" | grep -E 'i-[a-f0-9]{8,17}')" == "" ]]; then
-    echo "[ $(date) ] Need INSTANCE_ID like i-02cb1c2e2dececfcd, exiting"
+if [[ -z "$AWSREGION" ]] || [[ "${INSTANCE_ID}" == "" ]] || [[ "$(echo "${INSTANCE_ID}" | grep -E 'i-[a-f0-9]{8,17}')" == "" ]]; then
+    echo "[ $(date) ] IMDS unreachable or returned bad values (INSTANCE_ID='${INSTANCE_ID}' AWSREGION='${AWSREGION}'), exiting"
     exit 1
 fi
 

--- a/halt_it.sh
+++ b/halt_it.sh
@@ -209,14 +209,18 @@ else
 
     line_count=$(echo "${window_lines}" | grep -c .)
 
-    # Require 90% of expected samples so the full window is covered.
-    # At 10 s/sample, 90% of WINDOW_SECONDS = WINDOW_SECONDS * 9 / 100.
+    # Coverage check: require enough samples that the full window is represented.
+    # gpumon.SLEEP_INTERVAL = 10s nominal, but each loop adds ~1-2s of CloudWatch
+    # API latency (put_metric_data + get_metric_statistics x2), giving an actual
+    # cadence of ~11-12 s/sample. A strict 90% bound against the nominal 10s rate
+    # is unreachable on multi-GPU instances — the maximum physically possible
+    # line count is below the threshold. 70% of nominal leaves a safety margin
+    # while still rejecting the 1-h-idle / 1-h-active pattern in the 2-h window.
     # Multi-GPU instances write DTYPE lines per tick so multiply accordingly.
-    # This prevents a 1-h-idle / 1-h-active pattern from passing the 2-h check.
     if [ "${DTYPE}" -gt 0 ]; then
-        min_lines=$(( WINDOW_SECONDS * 9 / 100 * DTYPE ))
+        min_lines=$(( WINDOW_SECONDS * 7 / 100 * DTYPE ))
     else
-        min_lines=$(( WINDOW_SECONDS * 9 / 100 ))
+        min_lines=$(( WINDOW_SECONDS * 7 / 100 ))
     fi
     echo "[ $(date) ] Lines in window: ${line_count}  min required: ${min_lines}"
 

--- a/hostmon.py
+++ b/hostmon.py
@@ -134,18 +134,14 @@ def main() -> None:
     emp_name      = tags.get("Employee", "NO_TAG")
     policy        = tags.get("GPUMON_POLICY", "STANDARD")
 
-    # SPOT instances: never DM the employee
-    page_employee = (
-        policy != "SPOT"
-        and tags.get("PAGE_EMPLOYEE", "True").lower() != "false"
-    )
+    page_employee = tags.get("PAGE_EMPLOYEE", "True").lower() != "false"
 
     # Alert thresholds from env (with defaults)
     disk_alert_free_pct  = float(os.getenv("DISK_ALERT_FREE_PCT",    "10"))
     mem_alert_used_pct   = float(os.getenv("MEMORY_ALERT_USED_PCT",  "90"))
     alert_cooldown_hours = float(os.getenv("ALERT_COOLDOWN_HOURS",   "12"))
 
-    # Slack DM client — None if secret not configured, unreachable, or SPOT/disabled
+    # Slack DM client — None if secret not configured, unreachable, or PAGE_EMPLOYEE=false
     slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "IT/SLACK_BOT_TOKEN")
     slack_secret_region = os.getenv("GPUMON_SLACK_SECRET_REGION", os.getenv("GPUMON_SECRET_REGION", "eu-west-1"))
     dm_client = build_slack_dm_client(slack_secret_id, slack_secret_region) if page_employee else None

--- a/hostmon.py
+++ b/hostmon.py
@@ -1,0 +1,217 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0
+# Host-level metrics reporter for CloudWatch — (c) Paul Seifer, Autobrains LTD
+#
+# Reports to namespace "Host-metrics" every 60 seconds.  Completely independent
+# from gpumon.py/cpumon.py — writes its own log file (/tmp/HOSTMON_LOGS_*) and
+# never touches the GPU_TEMP_* or CPUMON_LOGS_* files that halt_it.sh reads.
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from time import sleep
+
+import boto3
+import psutil
+
+from mon_utils import (
+    build_slack_dm_client,
+    cleanup_old_logs,
+    fetch_instance_metadata,
+    get_instance_tags,
+    record_alert_sent,
+    should_send_alert,
+)
+
+NAMESPACE = "Host-metrics"
+TMP_FILE_PREFIX = "/tmp/HOSTMON_LOGS_"
+PUSH_INTERVAL = 60
+STORE_RESO = 60
+
+
+def _top_process_by_memory() -> tuple[str, float]:
+    best_name, best_pct = "unknown", 0.0
+    for proc in psutil.process_iter(["name", "memory_percent"]):
+        try:
+            pct = proc.info["memory_percent"] or 0.0
+            if pct > best_pct:
+                best_pct = pct
+                best_name = proc.info["name"] or "unknown"
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    return best_name, round(best_pct, 2)
+
+
+def _top_process_by_cpu() -> tuple[str, float]:
+    # Seed cpu_percent counters, then sample 1 s later for meaningful values
+    for proc in psutil.process_iter(["name"]):
+        try:
+            proc.cpu_percent(interval=None)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    sleep(1)
+    best_name, best_pct = "unknown", 0.0
+    for proc in psutil.process_iter(["name"]):
+        try:
+            pct = proc.cpu_percent(interval=None)
+            if pct > best_pct:
+                best_pct = pct
+                best_name = proc.info["name"] or "unknown"
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    return best_name, round(best_pct, 2)
+
+
+def _push_metrics(
+    cw_client,
+    dims: list[dict],
+    disk_free_bytes: float,
+    disk_free_pct: float,
+    mem_used_pct: float,
+    top_mem_proc: str,
+    top_mem_pct: float,
+    top_cpu_proc: str,
+    top_cpu_pct: float,
+) -> None:
+    mem_dims = dims + [{"Name": "TopMemoryProcessName", "Value": top_mem_proc[:256]}]
+    cpu_dims = dims + [{"Name": "TopCPUProcessName",    "Value": top_cpu_proc[:256]}]
+
+    cw_client.put_metric_data(
+        Namespace=NAMESPACE,
+        MetricData=[
+            {"MetricName": "Host Disk Free Bytes",              "Dimensions": dims,     "Unit": "Bytes",   "StorageResolution": STORE_RESO, "Value": disk_free_bytes},
+            {"MetricName": "Host Disk Free Percent",            "Dimensions": dims,     "Unit": "Percent", "StorageResolution": STORE_RESO, "Value": disk_free_pct},
+            {"MetricName": "Host Memory Used Percent",          "Dimensions": dims,     "Unit": "Percent", "StorageResolution": STORE_RESO, "Value": mem_used_pct},
+            {"MetricName": "Host Top Memory Process Percent",   "Dimensions": mem_dims, "Unit": "Percent", "StorageResolution": STORE_RESO, "Value": top_mem_pct},
+            {"MetricName": "Host Top CPU Process Percent",      "Dimensions": cpu_dims, "Unit": "Percent", "StorageResolution": STORE_RESO, "Value": top_cpu_pct},
+        ],
+    )
+
+
+def _log_results(
+    log_file: str,
+    current_time: datetime,
+    team: str,
+    emp_name: str,
+    disk_free_bytes: float,
+    disk_free_pct: float,
+    mem_used_pct: float,
+    top_mem_proc: str,
+    top_mem_pct: float,
+    top_cpu_proc: str,
+    top_cpu_pct: float,
+) -> None:
+    line = (
+        f"[ {current_time} ] "
+        f"tag:{team},"
+        f"Employee:{emp_name},"
+        f"DiskFreeBytes:{disk_free_bytes:.0f},"
+        f"DiskFreePct:{disk_free_pct:.1f},"
+        f"MemUsedPct:{mem_used_pct:.1f},"
+        f"TopMemProc:{top_mem_proc}({top_mem_pct:.1f}%),"
+        f"TopCPUProc:{top_cpu_proc}({top_cpu_pct:.1f}%)\n"
+    )
+    try:
+        with open(log_file, "a") as fh:
+            fh.write(line)
+    except OSError as exc:
+        print(f"hostmon log write error: {exc}")
+
+
+def main() -> None:
+    cleanup_old_logs(TMP_FILE_PREFIX, max_age_hours=48)
+
+    meta = fetch_instance_metadata()
+    region      = meta["region"]
+    instance_id = meta["instance_id"]
+
+    ec2 = boto3.client("ec2",        region_name=region)
+    cw  = boto3.client("cloudwatch", region_name=region)
+
+    tags = get_instance_tags(ec2, instance_id)
+    instance_name = tags.get("Name",     "NO_NAME_TAG")
+    team          = tags.get("Team",     "NO_TAG")
+    emp_name      = tags.get("Employee", "NO_TAG")
+    policy        = tags.get("GPUMON_POLICY", "STANDARD")
+
+    # SPOT instances: never DM the employee
+    page_employee = (
+        policy != "SPOT"
+        and tags.get("PAGE_EMPLOYEE", "True").lower() != "false"
+    )
+
+    # Alert thresholds from env (with defaults)
+    disk_alert_free_pct  = float(os.getenv("DISK_ALERT_FREE_PCT",    "10"))
+    mem_alert_used_pct   = float(os.getenv("MEMORY_ALERT_USED_PCT",  "90"))
+    alert_cooldown_hours = float(os.getenv("ALERT_COOLDOWN_HOURS",   "12"))
+
+    # Slack DM client — None if secret not configured, unreachable, or SPOT/disabled
+    slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "AB/SlackBotToken")
+    slack_secret_region = os.getenv("GPUMON_SLACK_SECRET_REGION", os.getenv("GPUMON_SECRET_REGION", "eu-west-1"))
+    dm_client = build_slack_dm_client(slack_secret_id, slack_secret_region) if page_employee else None
+
+    dims = [
+        {"Name": "InstanceId",   "Value": instance_id},
+        {"Name": "InstanceType", "Value": meta["instance_type"]},
+        {"Name": "InstanceTag",  "Value": team},
+        {"Name": "EmployeeTag",  "Value": emp_name},
+    ]
+
+    print(f"hostmon started — instance {instance_id} ({instance_name}) region {region} "
+          f"team {team} page_employee={page_employee}")
+
+    while True:
+        current_time = datetime.now()
+        log_file = TMP_FILE_PREFIX + current_time.strftime("%Y-%m-%dT%H")
+
+        try:
+            disk = psutil.disk_usage("/")
+            disk_free_bytes = float(disk.free)
+            disk_free_pct   = round(100.0 - disk.percent, 1)
+            disk_free_gb    = round(disk_free_bytes / 1024 ** 3, 1)
+
+            mem_used_pct = round(psutil.virtual_memory().percent, 1)
+
+            top_mem_proc, top_mem_pct = _top_process_by_memory()
+            top_cpu_proc, top_cpu_pct = _top_process_by_cpu()
+
+            _log_results(
+                log_file, current_time, team, emp_name,
+                disk_free_bytes, disk_free_pct, mem_used_pct,
+                top_mem_proc, top_mem_pct, top_cpu_proc, top_cpu_pct,
+            )
+
+            _push_metrics(
+                cw, dims,
+                disk_free_bytes, disk_free_pct, mem_used_pct,
+                top_mem_proc, top_mem_pct, top_cpu_proc, top_cpu_pct,
+            )
+
+            # ── Employee DM alerts (disk & memory only) ──────────────────────
+            if dm_client:
+                if disk_free_pct < disk_alert_free_pct and should_send_alert("disk_alert", alert_cooldown_hours):
+                    dm_client.send_dm(
+                        emp_name,
+                        f":warning: Disk space low on *{instance_name}*: "
+                        f"only {disk_free_pct:.1f}% free ({disk_free_gb} GB remaining).",
+                    )
+                    record_alert_sent("disk_alert")
+
+                if mem_used_pct > mem_alert_used_pct and should_send_alert("memory_alert", alert_cooldown_hours):
+                    dm_client.send_dm(
+                        emp_name,
+                        f":warning: Memory pressure on *{instance_name}*: "
+                        f"{mem_used_pct:.1f}% in use. "
+                        f"Top process: {top_mem_proc} ({top_mem_pct:.1f}%).",
+                    )
+                    record_alert_sent("memory_alert")
+
+        except Exception as exc:
+            print(f"hostmon iteration error: {exc}")
+
+        sleep(PUSH_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()

--- a/hostmon.py
+++ b/hostmon.py
@@ -20,8 +20,7 @@ from mon_utils import (
     cleanup_old_logs,
     fetch_instance_metadata,
     get_instance_tags,
-    record_alert_sent,
-    should_send_alert,
+    try_record_alert,
 )
 
 NAMESPACE = "Host-metrics"
@@ -190,22 +189,20 @@ def main() -> None:
 
             # ── Employee DM alerts (disk & memory only) ──────────────────────
             if dm_client:
-                if disk_free_pct < disk_alert_free_pct and should_send_alert("disk_alert", alert_cooldown_hours):
+                if disk_free_pct < disk_alert_free_pct and try_record_alert("disk_alert", alert_cooldown_hours):
                     dm_client.send_dm(
                         emp_name,
                         f":warning: Disk space low on *{instance_name}*: "
                         f"only {disk_free_pct:.1f}% free ({disk_free_gb} GB remaining).",
                     )
-                    record_alert_sent("disk_alert")
 
-                if mem_used_pct > mem_alert_used_pct and should_send_alert("memory_alert", alert_cooldown_hours):
+                if mem_used_pct > mem_alert_used_pct and try_record_alert("memory_alert", alert_cooldown_hours):
                     dm_client.send_dm(
                         emp_name,
                         f":warning: Memory pressure on *{instance_name}*: "
                         f"{mem_used_pct:.1f}% in use. "
                         f"Top process: {top_mem_proc} ({top_mem_pct:.1f}%).",
                     )
-                    record_alert_sent("memory_alert")
 
         except Exception as exc:
             print(f"hostmon iteration error: {exc}")

--- a/hostmon.py
+++ b/hostmon.py
@@ -146,7 +146,7 @@ def main() -> None:
     alert_cooldown_hours = float(os.getenv("ALERT_COOLDOWN_HOURS",   "12"))
 
     # Slack DM client — None if secret not configured, unreachable, or SPOT/disabled
-    slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "AB/SlackBotToken")
+    slack_secret_id     = os.getenv("GPUMON_SLACK_SECRET_ID", "IT/SLACK_BOT_TOKEN")
     slack_secret_region = os.getenv("GPUMON_SLACK_SECRET_REGION", os.getenv("GPUMON_SECRET_REGION", "eu-west-1"))
     dm_client = build_slack_dm_client(slack_secret_id, slack_secret_region) if page_employee else None
 

--- a/kill_halt.sh
+++ b/kill_halt.sh
@@ -1,21 +1,27 @@
 #!/bin/bash
-#this scriptlet looks for halt_it.sh processes and stops them and then adds timestamp into /tmp/timestamp.txt so that halt_it script can back off for 2 hours even if instance is idle. (c)Paul Seifer
+# Kill any running halt_it.sh process and set a 2-hour shutdown backoff.
+# (c) Paul Seifer, Autobrains LTD
+
+TIMESTAMP_FILE="/tmp/timestamp.txt"
+
 pgrep -f "halt_it.sh"
 targetproc=($(pgrep -f "halt_it.sh"))
+
 if [ "${#targetproc[@]}" -eq 0 ]; then
-        echo "No related process seems to be running, exiting without doing anything"
-        exit 1
-else
-        echo "Currently running processes related to putting server to sleep:${targetproc[@]}"
-        for tp in "${targetproc[@]}"; do 
-                kill $tp
-                sleep 1
-                if kill -0 $tp 2>/dev/null; then
-                    kill -9 $tp
-                fi
-                echo "Killed running process:${tp}"
-        done
-        TIMESTAMP_FILE="/tmp/timestamp.txt"
-        date +%s > "${TIMESTAMP_FILE}"
-        echo "$(cat ${TIMESTAMP_FILE}) - the server shutdown will be delayed for 2 hours"
+    echo "No related process seems to be running, exiting without doing anything"
+    exit 1
 fi
+
+echo "Currently running processes related to putting server to sleep: ${targetproc[*]}"
+for tp in "${targetproc[@]}"; do
+    kill "$tp"
+    sleep 1
+    if kill -0 "$tp" 2>/dev/null; then
+        kill -9 "$tp"
+    fi
+    echo "Killed running process: ${tp}"
+done
+
+# Write human-readable date so halt_it.sh can parse it with `date -d`
+date > "${TIMESTAMP_FILE}"
+echo "$(cat "${TIMESTAMP_FILE}") — server shutdown delayed for 2 hours"

--- a/kill_halt.sh
+++ b/kill_halt.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
-# Kill any running halt_it.sh process and set a 2-hour shutdown backoff.
+# Write a 2-hour shutdown backoff and kill any running halt_it.sh process.
+# Safe to run proactively — does not require halt_it.sh to be running.
 # (c) Paul Seifer, Autobrains LTD
 
 TIMESTAMP_FILE="/tmp/timestamp.txt"
 
-pgrep -f "halt_it.sh"
-targetproc=($(pgrep -f "halt_it.sh"))
+# Always set the backoff timestamp first so shutdown is delayed regardless
+# of whether halt_it.sh is currently executing.
+date > "${TIMESTAMP_FILE}"
+echo "[ $(date) ] Shutdown backoff set — halt_it.sh suppressed for 2 hours."
+
+targetproc=($(pgrep -f "halt_it.sh" 2>/dev/null))
 
 if [ "${#targetproc[@]}" -eq 0 ]; then
-    echo "No related process seems to be running, exiting without doing anything"
-    exit 1
+    echo "No halt_it.sh process currently running."
+    exit 0
 fi
 
-echo "Currently running processes related to putting server to sleep: ${targetproc[*]}"
+echo "Killing running halt_it.sh processes: ${targetproc[*]}"
 for tp in "${targetproc[@]}"; do
-    kill "$tp"
-    sleep 1
+    kill "$tp" 2>/dev/null && sleep 1 || true
     if kill -0 "$tp" 2>/dev/null; then
-        kill -9 "$tp"
+        kill -9 "$tp" 2>/dev/null || true
     fi
-    echo "Killed running process: ${tp}"
+    echo "Killed process: ${tp}"
 done
-
-# Write human-readable date so halt_it.sh can parse it with `date -d`
-date > "${TIMESTAMP_FILE}"
-echo "$(cat "${TIMESTAMP_FILE}") — server shutdown delayed for 2 hours"

--- a/kill_halt.sh
+++ b/kill_halt.sh
@@ -1,14 +1,35 @@
 #!/bin/bash
-# Write a 2-hour shutdown backoff and kill any running halt_it.sh process.
+# Write a policy-aware shutdown backoff and kill any running halt_it.sh process.
 # Safe to run proactively — does not require halt_it.sh to be running.
 # (c) Paul Seifer, Autobrains LTD
+
+# Fetch POLICY so the backoff duration matches the idle window for this instance.
+TOKEN=$(curl -s --max-time 5 -X PUT "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" 2>/dev/null)
+AWSREGION=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
+    http://169.254.169.254/latest/meta-data/placement/region 2>/dev/null)
+INSTANCE_ID=$(curl -s --max-time 5 -H "X-aws-ec2-metadata-token: $TOKEN" \
+    http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
+POLICY=$(aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=${INSTANCE_ID}" "Name=key,Values=GPUMON_POLICY" \
+    --query "Tags[0].Value" --output text --region "${AWSREGION}" 2>/dev/null)
+if [ -z "${POLICY}" ] || [ "${POLICY}" = "None" ]; then
+    POLICY="STANDARD"
+fi
+
+# SPOT/SEVERE: 30-min backoff (2× the 15-min idle window)
+# All others:  2-hour backoff (matches the 2-hour idle window)
+case "$POLICY" in
+    SPOT|SEVERE) BACKOFF_SECS=$((30 * 60)) ;;
+    *)           BACKOFF_SECS=$((2 * 60 * 60)) ;;
+esac
 
 TIMESTAMP_FILE="/tmp/timestamp.txt"
 
 # Always set the backoff timestamp first so shutdown is delayed regardless
 # of whether halt_it.sh is currently executing.
 date > "${TIMESTAMP_FILE}"
-echo "[ $(date) ] Shutdown backoff set — halt_it.sh suppressed for 2 hours."
+echo "[ $(date) ] Shutdown backoff set — policy=${POLICY} duration=${BACKOFF_SECS}s — halt_it.sh suppressed."
 
 targetproc=($(pgrep -f "halt_it.sh" 2>/dev/null))
 

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -50,9 +50,17 @@ def install_commands(branch: str) -> list[str]:
     ]
 
 # Fix step 1 (fast path): pull latest code and rebuild the running container.
+# Use fetch + reset --hard @{upstream} rather than git pull --force: it explicitly
+# resets to the tracked remote branch and does not drift if the local HEAD somehow
+# moved (e.g. a legacy update timer switched the branch to main).
+# The docker compose command mirrors autoinstall.sh's GPU vs CPU selection.
 FIX_STEP1_COMMANDS = [
-    f"cd {GPUMON_DIR} && sudo git pull --force",
-    f"cd {GPUMON_DIR} && sudo docker compose up -d --build",
+    f"cd {GPUMON_DIR} && sudo git fetch origin && sudo git reset --hard @{{upstream}}",
+    f"if nvidia-smi --list-gpus >/dev/null 2>&1 && [ \"$(nvidia-smi --list-gpus | wc -l)\" -gt 0 ]; then "
+    f"  sudo docker compose -f {GPUMON_DIR}/docker-compose.yml up -d --build; "
+    f"else "
+    f"  sudo docker compose -f {GPUMON_DIR}/docker-compose.yml -f {GPUMON_DIR}/docker-compose.cpu.yml up -d --build; "
+    f"fi",
 ]
 
 # Fix step 2 (full reinstall): reset sentinel so autoinstall.sh re-runs everything.

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -41,6 +41,10 @@ def install_commands(branch: str) -> list[str]:
     """Clone the given branch and run autoinstall.sh."""
     branch = _validate_branch(branch)
     return [
+        # Stop automatic update services so they don't hold the apt lock for
+        # longer than our DPkg::Lock::Timeout can wait.
+        "sudo systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true",
+        "while sudo fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend /var/cache/apt/archives/lock >/dev/null 2>&1; do echo 'waiting for apt lock...'; sleep 5; done",
         "sudo apt-get -o DPkg::Lock::Timeout=120 update -q",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y git",
         f"sudo rm -f {SENTINEL}",
@@ -102,6 +106,9 @@ def migrate_commands(branch: str) -> list[str]:
         "crontab -l 2>/dev/null | grep -v halt_it.sh | grep -v gpumon | crontab - || true",
         # ── Drop sentinel so autoinstall.sh always runs end-to-end ──
         f"sudo rm -f {SENTINEL}",
+        # ── Stop automatic update services so they don't hold the apt lock ──
+        "sudo systemctl stop unattended-upgrades apt-daily.service apt-daily-upgrade.service 2>/dev/null || true",
+        "while sudo fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/lib/dpkg/lock-frontend /var/cache/apt/archives/lock >/dev/null 2>&1; do echo 'waiting for apt lock...'; sleep 5; done",
         # ── Fresh clone at the Docker branch ──
         f"sudo rm -rf {GPUMON_DIR}",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y git -q",

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -41,8 +41,8 @@ def install_commands(branch: str) -> list[str]:
     """Clone the given branch and run autoinstall.sh."""
     branch = _validate_branch(branch)
     return [
-        "sudo apt-get update -q",
-        "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git",
+        "sudo apt-get -o DPkg::Lock::Timeout=120 update -q",
+        "sudo DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y git",
         f"sudo rm -f {SENTINEL}",
         f"sudo rm -rf {GPUMON_DIR}",
         f"sudo git clone --branch {branch} {GPUMON_REPO} {GPUMON_DIR}",
@@ -96,7 +96,7 @@ def migrate_commands(branch: str) -> list[str]:
         f"sudo rm -f {SENTINEL}",
         # ── Fresh clone at the Docker branch ──
         f"sudo rm -rf {GPUMON_DIR}",
-        "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git -q",
+        "sudo DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=120 install -y git -q",
         f"sudo git clone --branch {branch} {GPUMON_REPO} {GPUMON_DIR}",
         # ── Full Docker install ──
         f"sudo bash {GPUMON_DIR}/autoinstall.sh",

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -486,6 +486,12 @@ def lambda_handler(event, context):
                     else:
                         print(f"[{instance_id}] MIGRATE skipped — instance not running")
 
+                elif tag_value == "DELETE":
+                    if state == "running":
+                        handle_delete(ec2, ssm, instance_id)
+                    else:
+                        print(f"[{instance_id}] DELETE pending — instance not running, will retry when running")
+
                 elif state != "running" and tag_value not in ("", "INACTIVE"):
                     update_tag(ec2, instance_id, "INACTIVE")
 
@@ -495,12 +501,12 @@ def lambda_handler(event, context):
                 elif state == "running" and tag_value in ("ACTIVE", "INACTIVE"):
                     handle_check(ec2, ssm, instance_id)
 
-                elif tag_value == "DELETE":
-                    handle_delete(ec2, ssm, instance_id)
-
                 elif tag_value == "NOT_FIXED":
                     print(f"[{instance_id}] NOT_FIXED — skipping until manually resolved")
 
+            except ValueError as e:
+                print(f"[{region}][{instance_id}] invalid GPUMON_BRANCH tag — {e}")
+                update_tag(ec2, instance_id, "FAILED")
             except ClientError as e:
                 if e.response["Error"]["Code"] == "RequestLimitExceeded":
                     print(f"[{region}] rate limited — backing off 5 s")

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -1,4 +1,5 @@
 import boto3
+import re
 import time
 from botocore.exceptions import ClientError
 
@@ -6,11 +7,21 @@ from botocore.exceptions import ClientError
 # Constants
 # ---------------------------------------------------------------------------
 REGIONS = ["eu-west-1", "eu-central-1", "us-east-1"]
-IAM_ROLE_NAME   = "EC2IAMRole"
-TAG_KEY         = "GPUMON"
-BRANCH_TAG_KEY  = "GPUMON_BRANCH"   # optional per-instance override
-DEFAULT_BRANCH  = "main"            # legacy instances track main
-DOCKER_BRANCH   = "feature/dockerize"  # update to "main" once merged
+IAM_ROLE_NAME  = "EC2IAMRole"
+TAG_KEY        = "GPUMON"
+BRANCH_TAG_KEY = "GPUMON_BRANCH"       # optional per-instance branch override
+
+# All new installs and migrations use DOCKER_BRANCH.
+# Update this constant to "main" once feature/dockerize is merged.
+DOCKER_BRANCH  = "feature/dockerize"
+
+_VALID_BRANCH_RE = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9/_.-]{0,99}$')
+
+def _validate_branch(branch: str) -> str:
+    """Raise ValueError if branch name contains shell-unsafe characters."""
+    if not _VALID_BRANCH_RE.match(branch):
+        raise ValueError(f"Unsafe branch name rejected: {branch!r}")
+    return branch
 
 SSM_COMMAND_POLL_INTERVAL = 5    # seconds between status polls
 SSM_CHECK_TIMEOUT   = 30         # quick is-running checks
@@ -28,6 +39,7 @@ SENTINEL    = "/var/log/gpumon.finished"
 
 def install_commands(branch: str) -> list[str]:
     """Clone the given branch and run autoinstall.sh."""
+    branch = _validate_branch(branch)
     return [
         "sudo apt-get update -q",
         "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git",
@@ -63,6 +75,7 @@ DELETE_COMMANDS = [
 
 def migrate_commands(branch: str) -> list[str]:
     """Stop all legacy gpumon artifacts and install the Docker deployment from branch."""
+    branch = _validate_branch(branch)
     return [
         # ── Stop and remove legacy systemd units ──
         "for svc in gpumon cpumon gpumon-monitor; do "
@@ -191,10 +204,12 @@ def is_gpumon_running(ssm, instance_id: str) -> bool:
         [
             # New: Docker container named gpumon is running
             "( docker ps --filter 'name=gpumon' --filter 'status=running' --quiet 2>/dev/null | grep -q . && echo active ) || "
-            # Legacy: gpumon.py process running directly
+            # Legacy: gpumon.py or cpumon.py process running directly
             "( pgrep -f 'python.*gpumon\\.py' >/dev/null 2>&1 && echo active ) || "
-            # Legacy: systemd service active
+            "( pgrep -f 'python.*cpumon\\.py' >/dev/null 2>&1 && echo active ) || "
+            # Legacy: systemd service active (gpu or cpu variant)
             "( systemctl is-active --quiet gpumon 2>/dev/null && echo active ) || "
+            "( systemctl is-active --quiet cpumon 2>/dev/null && echo active ) || "
             "echo inactive"
         ],
         poll_timeout=SSM_CHECK_TIMEOUT,
@@ -376,11 +391,13 @@ def handle_delete(ec2, ssm, instance_id: str) -> None:
         poll_timeout=SSM_FIX_TIMEOUT,
         execution_timeout=SSM_FIX_TIMEOUT,
     )
-    if inv is not None:
+    if inv is not None and inv.get("Status") == "Success":
         update_tag(ec2, instance_id, "")
         print(f"[{instance_id}] gpumon removed")
     else:
-        print(f"[{instance_id}] delete command failed")
+        status = inv.get("Status") if inv else "no response"
+        print(f"[{instance_id}] delete command failed (status: {status})")
+        update_tag(ec2, instance_id, "FAILED")
 
 
 def handle_migrate(ec2, ssm, instance_id: str, branch: str) -> None:
@@ -456,7 +473,7 @@ def lambda_handler(event, context):
 
             try:
                 if tag_value.lower() == "install" or tag_value == "PENDING_SSM":
-                    branch = branch_override or DEFAULT_BRANCH
+                    branch = branch_override or DOCKER_BRANCH
                     if state == "running":
                         handle_install(ec2, ssm, instance_id, branch)
                     else:

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -256,6 +256,25 @@ def is_gpumon_dockerized(ssm, instance_id: str) -> bool:
     return inv.get("StandardOutputContent", "").strip() == "active"
 
 
+def _has_docker_deployment(ssm, instance_id: str) -> bool:
+    """Return True if a Docker gpumon deployment was installed on this instance.
+
+    Checks for the sentinel file written at the end of autoinstall.sh.  The
+    container may be stopped or broken — this probes deployment existence, not
+    health.  A legacy instance (never Dockerized) will not have the sentinel.
+    """
+    inv = run_ssm_command(
+        ssm,
+        instance_id,
+        [f"test -f {SENTINEL} && echo yes || echo no"],
+        poll_timeout=SSM_CHECK_TIMEOUT,
+        execution_timeout=30,
+    )
+    if inv is None:
+        return False
+    return inv.get("StandardOutputContent", "").strip() == "yes"
+
+
 # ---------------------------------------------------------------------------
 # IAM role management
 # ---------------------------------------------------------------------------
@@ -351,23 +370,19 @@ def handle_fix(ec2, ssm, instance_id: str) -> None:
     """Progressive fix for FAILED Docker instances.
 
     Step 1 (fast): pull latest code, rebuild and restart the container.
-    Step 2 (full): reset sentinel and re-run autoinstall.sh end-to-end.
+    Step 2 (full): re-clone the repo and run autoinstall.sh end-to-end.
     If still broken: tag NOT_FIXED for manual attention.
 
     Legacy (non-Docker) instances that go FAILED are not auto-fixed here —
     they are tagged NOT_FIXED with a message to set GPUMON=MIGRATE manually.
     """
-    # Refuse to run Docker fix commands on legacy instances to avoid
-    # inadvertently migrating them without operator intent.
-    inv = run_ssm_command(
-        ssm, instance_id,
-        ["docker info >/dev/null 2>&1 && echo docker-present || echo no-docker"],
-        poll_timeout=SSM_CHECK_TIMEOUT,
-        execution_timeout=30,
-    )
-    if inv is None or inv.get("StandardOutputContent", "").strip() != "docker-present":
-        print(f"[{instance_id}] Docker not found — this is a legacy instance; "
-              "set GPUMON=MIGRATE to upgrade it to Docker")
+    # Guard: require an existing Docker gpumon deployment (sentinel present).
+    # docker info alone is insufficient — a legacy instance may have Docker
+    # installed without gpumon being containerized.  The sentinel is written at
+    # the end of autoinstall.sh and survives a stopped/broken container.
+    if not _has_docker_deployment(ssm, instance_id):
+        print(f"[{instance_id}] no Docker gpumon deployment found — "
+              "set GPUMON=MIGRATE to upgrade this legacy instance")
         update_tag(ec2, instance_id, "NOT_FIXED")
         return
 
@@ -382,7 +397,10 @@ def handle_fix(ec2, ssm, instance_id: str) -> None:
         return
 
     time.sleep(5)
-    if is_gpumon_running(ssm, instance_id):
+    # Only declare step 1 success if the SSM command itself exited 0 AND
+    # the Docker container is now running.  is_gpumon_running() is intentionally
+    # NOT used here: a surviving legacy process must not mask a failed Docker fix.
+    if inv["Status"] == "Success" and is_gpumon_dockerized(ssm, instance_id):
         print(f"[{instance_id}] fixed by step 1")
         update_tag(ec2, instance_id, "ACTIVE")
         return
@@ -393,12 +411,12 @@ def handle_fix(ec2, ssm, instance_id: str) -> None:
         poll_timeout=SSM_INSTALL_TIMEOUT,
         execution_timeout=SSM_INSTALL_TIMEOUT,
     )
-    if inv is None:
+    if inv is None or inv["Status"] != "Success":
         update_tag(ec2, instance_id, "NOT_FIXED")
         return
 
     time.sleep(5)
-    if is_gpumon_running(ssm, instance_id):
+    if is_gpumon_dockerized(ssm, instance_id):
         print(f"[{instance_id}] fixed by step 2")
         update_tag(ec2, instance_id, "ACTIVE")
     else:

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -257,16 +257,20 @@ def is_gpumon_dockerized(ssm, instance_id: str) -> bool:
 
 
 def _has_docker_deployment(ssm, instance_id: str) -> bool:
-    """Return True if a Docker gpumon deployment was installed on this instance.
+    """Return True if a Docker gpumon deployment exists on this instance.
 
-    Checks for the sentinel file written at the end of autoinstall.sh.  The
-    container may be stopped or broken — this probes deployment existence, not
-    health.  A legacy instance (never Dockerized) will not have the sentinel.
+    Accepts either the sentinel file (written at end of autoinstall.sh) OR the
+    presence of docker-compose.yml in GPUMON_DIR.  The boot service restarts the
+    container without recreating the sentinel, so either marker is sufficient.
+    A legacy instance (never Dockerized) will have neither.
     """
+    # Check sentinel OR compose file: gpumon-boot.service starts the container
+    # without recreating the sentinel, so a running post-boot instance may lack
+    # the sentinel while docker-compose.yml is present in GPUMON_DIR.
     inv = run_ssm_command(
         ssm,
         instance_id,
-        [f"test -f {SENTINEL} && echo yes || echo no"],
+        [f"{{ test -f {SENTINEL} || test -f {GPUMON_DIR}/docker-compose.yml; }} && echo yes || echo no"],
         poll_timeout=SSM_CHECK_TIMEOUT,
         execution_timeout=30,
     )

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -1,0 +1,494 @@
+import boto3
+import time
+from botocore.exceptions import ClientError
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+REGIONS = ["eu-west-1", "eu-central-1", "us-east-1"]
+IAM_ROLE_NAME   = "EC2IAMRole"
+TAG_KEY         = "GPUMON"
+BRANCH_TAG_KEY  = "GPUMON_BRANCH"   # optional per-instance override
+DEFAULT_BRANCH  = "main"            # legacy instances track main
+DOCKER_BRANCH   = "feature/dockerize"  # update to "main" once merged
+
+SSM_COMMAND_POLL_INTERVAL = 5    # seconds between status polls
+SSM_CHECK_TIMEOUT   = 30         # quick is-running checks
+SSM_FIX_TIMEOUT     = 180        # re-clone + rebuild
+SSM_INSTALL_TIMEOUT = 900        # full Docker install (apt + image pull + build)
+SSM_MIGRATE_TIMEOUT = 1200       # migration: stop old + full reinstall
+
+GPUMON_REPO = "https://github.com/autobrains/gpumon.git"
+GPUMON_DIR  = "/root/gpumon"
+SENTINEL    = "/var/log/gpumon.finished"
+
+# ---------------------------------------------------------------------------
+# SSM command bundles
+# ---------------------------------------------------------------------------
+
+def install_commands(branch: str) -> list[str]:
+    """Clone the given branch and run autoinstall.sh."""
+    return [
+        "sudo apt-get update -q",
+        "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git",
+        f"sudo rm -f {SENTINEL}",
+        f"sudo rm -rf {GPUMON_DIR}",
+        f"sudo git clone --branch {branch} {GPUMON_REPO} {GPUMON_DIR}",
+        f"sudo bash {GPUMON_DIR}/autoinstall.sh",
+    ]
+
+# Fix step 1 (fast path): pull latest code and rebuild the running container.
+FIX_STEP1_COMMANDS = [
+    f"cd {GPUMON_DIR} && sudo git pull --force",
+    f"cd {GPUMON_DIR} && sudo docker compose up -d --build",
+]
+
+# Fix step 2 (full reinstall): reset sentinel so autoinstall.sh re-runs everything.
+FIX_STEP2_COMMANDS = [
+    f"sudo rm -f {SENTINEL}",
+    f"sudo bash {GPUMON_DIR}/autoinstall.sh",
+]
+
+# Delete: stop stack, remove timer and crontab entry, wipe repo.
+DELETE_COMMANDS = [
+    f"cd {GPUMON_DIR} && sudo docker compose down || true",
+    "sudo systemctl disable --now gpumon-update.timer 2>/dev/null || true",
+    "sudo rm -f /etc/systemd/system/gpumon-update.service /etc/systemd/system/gpumon-update.timer",
+    "sudo systemctl daemon-reload 2>/dev/null || true",
+    "crontab -l 2>/dev/null | grep -v halt_it.sh | crontab - || true",
+    "sudo rm -f /usr/local/sbin/halt_it.sh /usr/local/sbin/gpumon-update.sh",
+    f"sudo rm -rf {GPUMON_DIR}",
+    f"sudo rm -f {SENTINEL}",
+]
+
+def migrate_commands(branch: str) -> list[str]:
+    """Stop all legacy gpumon artifacts and install the Docker deployment from branch."""
+    return [
+        # ── Stop and remove legacy systemd units ──
+        "for svc in gpumon cpumon gpumon-monitor; do "
+        "  sudo systemctl stop $svc 2>/dev/null || true; "
+        "  sudo systemctl disable $svc 2>/dev/null || true; "
+        "done",
+        "sudo rm -f /etc/systemd/system/gpumon.service "
+        "          /etc/systemd/system/cpumon.service "
+        "          /etc/systemd/system/gpumon-monitor.service",
+        "sudo systemctl daemon-reload 2>/dev/null || true",
+        # ── Kill any directly-running monitor processes ──
+        "sudo pkill -f 'python.*gpumon\\.py' 2>/dev/null || true",
+        "sudo pkill -f 'python.*cpumon\\.py'  2>/dev/null || true",
+        "sudo pkill -f 'python.*hostmon\\.py' 2>/dev/null || true",
+        # ── Remove legacy crontab entries (halt_it.sh re-added by autoinstall) ──
+        "crontab -l 2>/dev/null | grep -v halt_it.sh | grep -v gpumon | crontab - || true",
+        # ── Drop sentinel so autoinstall.sh always runs end-to-end ──
+        f"sudo rm -f {SENTINEL}",
+        # ── Fresh clone at the Docker branch ──
+        f"sudo rm -rf {GPUMON_DIR}",
+        "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git -q",
+        f"sudo git clone --branch {branch} {GPUMON_REPO} {GPUMON_DIR}",
+        # ── Full Docker install ──
+        f"sudo bash {GPUMON_DIR}/autoinstall.sh",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def get_clients(region: str):
+    return (
+        boto3.client("ec2", region_name=region),
+        boto3.client("ssm", region_name=region),
+    )
+
+
+def get_all_instances(ec2) -> list:
+    instances = []
+    paginator = ec2.get_paginator("describe_instances")
+    for page in paginator.paginate():
+        for reservation in page["Reservations"]:
+            instances.extend(reservation["Instances"])
+    return instances
+
+
+def get_gpumon_tag(instance) -> dict | None:
+    for tag in instance.get("Tags", []):
+        if tag["Key"] == TAG_KEY:
+            return tag
+    return None
+
+
+def update_tag(ec2, instance_id: str, value: str) -> None:
+    try:
+        ec2.create_tags(
+            Resources=[instance_id],
+            Tags=[{"Key": TAG_KEY, "Value": value}],
+        )
+        print(f"[{instance_id}] tag → {value!r}")
+    except ClientError as e:
+        print(f"[{instance_id}] error updating tag: {e}")
+
+
+# ---------------------------------------------------------------------------
+# SSM
+# ---------------------------------------------------------------------------
+
+def run_ssm_command(
+    ssm,
+    instance_id: str,
+    commands: list[str],
+    poll_timeout: int = SSM_CHECK_TIMEOUT,
+    execution_timeout: int = 300,
+) -> dict | None:
+    """Send SSM RunShellScript and poll until terminal status.
+
+    poll_timeout       – how long to wait for the command to reach a terminal
+                         state before giving up.
+    execution_timeout  – passed to SSM as TimeoutSeconds (delivery + execution
+                         window).  Increase for long-running commands.
+    """
+    try:
+        resp = ssm.send_command(
+            InstanceIds=[instance_id],
+            DocumentName="AWS-RunShellScript",
+            Parameters={"commands": commands},
+            TimeoutSeconds=execution_timeout,
+        )
+    except ClientError as e:
+        print(f"[{instance_id}] SSM send_command failed: {e}")
+        return None
+
+    command_id = resp["Command"]["CommandId"]
+    print(f"[{instance_id}] SSM command {command_id} sent")
+
+    elapsed = 0
+    while elapsed < poll_timeout:
+        time.sleep(SSM_COMMAND_POLL_INTERVAL)
+        elapsed += SSM_COMMAND_POLL_INTERVAL
+        try:
+            inv = ssm.get_command_invocation(
+                CommandId=command_id, InstanceId=instance_id
+            )
+            status = inv["Status"]
+            if status in ("Success", "Failed", "TimedOut", "Cancelled"):
+                print(f"[{instance_id}] SSM finished: {status}")
+                return inv
+        except ssm.exceptions.InvocationDoesNotExist:
+            continue  # command hasn't registered yet
+        except ClientError as e:
+            print(f"[{instance_id}] polling error: {e}")
+            return None
+
+    print(f"[{instance_id}] SSM poll timed out after {poll_timeout}s")
+    return None
+
+
+def is_gpumon_running(ssm, instance_id: str) -> bool:
+    """Return True if gpumon is running — either the Docker container (new) or
+    the legacy direct-Python process / systemd service (old)."""
+    inv = run_ssm_command(
+        ssm,
+        instance_id,
+        [
+            # New: Docker container named gpumon is running
+            "( docker ps --filter 'name=gpumon' --filter 'status=running' --quiet 2>/dev/null | grep -q . && echo active ) || "
+            # Legacy: gpumon.py process running directly
+            "( pgrep -f 'python.*gpumon\\.py' >/dev/null 2>&1 && echo active ) || "
+            # Legacy: systemd service active
+            "( systemctl is-active --quiet gpumon 2>/dev/null && echo active ) || "
+            "echo inactive"
+        ],
+        poll_timeout=SSM_CHECK_TIMEOUT,
+        execution_timeout=30,
+    )
+    if inv is None:
+        return False
+    return inv.get("StandardOutputContent", "").strip() == "active"
+
+
+def is_gpumon_dockerized(ssm, instance_id: str) -> bool:
+    """Return True only if the Docker container (new deployment) is running."""
+    inv = run_ssm_command(
+        ssm,
+        instance_id,
+        ["docker ps --filter 'name=gpumon' --filter 'status=running' --quiet | grep -q . && echo active || echo inactive"],
+        poll_timeout=SSM_CHECK_TIMEOUT,
+        execution_timeout=30,
+    )
+    if inv is None:
+        return False
+    return inv.get("StandardOutputContent", "").strip() == "active"
+
+
+# ---------------------------------------------------------------------------
+# IAM role management
+# ---------------------------------------------------------------------------
+
+def ensure_iam_role(ec2, instance_id: str) -> bool:
+    """Attach IAM_ROLE_NAME instance profile if not already present."""
+    try:
+        details = ec2.describe_instances(InstanceIds=[instance_id])
+        instance = details["Reservations"][0]["Instances"][0]
+    except (ClientError, IndexError, KeyError) as e:
+        print(f"[{instance_id}] error describing instance: {e}")
+        return False
+
+    profile = instance.get("IamInstanceProfile")
+    if profile and IAM_ROLE_NAME in profile["Arn"]:
+        print(f"[{instance_id}] IAM role already attached")
+        return True
+
+    if profile:
+        try:
+            assocs = ec2.describe_iam_instance_profile_associations(
+                Filters=[{"Name": "instance-id", "Values": [instance_id]}]
+            )
+            for assoc in assocs["IamInstanceProfileAssociations"]:
+                if assoc["State"] == "associated":
+                    ec2.disassociate_iam_instance_profile(
+                        AssociationId=assoc["AssociationId"]
+                    )
+                    print(f"[{instance_id}] disassociated existing IAM profile")
+                    time.sleep(3)
+        except ClientError as e:
+            print(f"[{instance_id}] error disassociating profile: {e}")
+            return False
+
+    try:
+        ec2.associate_iam_instance_profile(
+            IamInstanceProfile={"Name": IAM_ROLE_NAME},
+            InstanceId=instance_id,
+        )
+        print(f"[{instance_id}] attached IAM role '{IAM_ROLE_NAME}'")
+        return True
+    except ClientError as e:
+        print(f"[{instance_id}] error attaching IAM role: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Core actions
+# ---------------------------------------------------------------------------
+
+def handle_install(ec2, ssm, instance_id: str, branch: str) -> None:
+    """Ensure IAM role, clone branch, run autoinstall.sh, verify container."""
+    if not ensure_iam_role(ec2, instance_id):
+        update_tag(ec2, instance_id, "FAILED")
+        return
+
+    print(f"[{instance_id}] installing from branch '{branch}'")
+    inv = run_ssm_command(
+        ssm,
+        instance_id,
+        install_commands(branch),
+        poll_timeout=SSM_INSTALL_TIMEOUT,
+        execution_timeout=SSM_INSTALL_TIMEOUT,
+    )
+    if inv is None:
+        print(f"[{instance_id}] install command could not be sent — SSM agent may be absent")
+        update_tag(ec2, instance_id, "PENDING_SSM")
+        return
+
+    if inv["Status"] != "Success":
+        print(f"[{instance_id}] install script exited non-zero: {inv.get('StandardErrorContent', '')[:300]}")
+        update_tag(ec2, instance_id, "FAILED")
+        return
+
+    time.sleep(5)
+    if is_gpumon_dockerized(ssm, instance_id):
+        update_tag(ec2, instance_id, "ACTIVE")
+    else:
+        update_tag(ec2, instance_id, "FAILED")
+
+
+def handle_check(ec2, ssm, instance_id: str) -> None:
+    """Verify gpumon is running (Docker or legacy) and update the tag.
+    Migration from legacy to Docker is triggered manually via GPUMON=MIGRATE.
+    """
+    if is_gpumon_running(ssm, instance_id):
+        update_tag(ec2, instance_id, "ACTIVE")
+    else:
+        update_tag(ec2, instance_id, "FAILED")
+
+
+def handle_fix(ec2, ssm, instance_id: str) -> None:
+    """Progressive fix for FAILED Docker instances.
+
+    Step 1 (fast): pull latest code, rebuild and restart the container.
+    Step 2 (full): reset sentinel and re-run autoinstall.sh end-to-end.
+    If still broken: tag NOT_FIXED for manual attention.
+
+    Legacy (non-Docker) instances that go FAILED are not auto-fixed here —
+    they are tagged NOT_FIXED with a message to set GPUMON=MIGRATE manually.
+    """
+    # Refuse to run Docker fix commands on legacy instances to avoid
+    # inadvertently migrating them without operator intent.
+    inv = run_ssm_command(
+        ssm, instance_id,
+        ["docker info >/dev/null 2>&1 && echo docker-present || echo no-docker"],
+        poll_timeout=SSM_CHECK_TIMEOUT,
+        execution_timeout=30,
+    )
+    if inv is None or inv.get("StandardOutputContent", "").strip() != "docker-present":
+        print(f"[{instance_id}] Docker not found — this is a legacy instance; "
+              "set GPUMON=MIGRATE to upgrade it to Docker")
+        update_tag(ec2, instance_id, "NOT_FIXED")
+        return
+
+    print(f"[{instance_id}] starting fix — step 1: pull + rebuild")
+    inv = run_ssm_command(
+        ssm, instance_id, FIX_STEP1_COMMANDS,
+        poll_timeout=SSM_FIX_TIMEOUT,
+        execution_timeout=SSM_FIX_TIMEOUT,
+    )
+    if inv is None:
+        update_tag(ec2, instance_id, "NOT_FIXED")
+        return
+
+    time.sleep(5)
+    if is_gpumon_running(ssm, instance_id):
+        print(f"[{instance_id}] fixed by step 1")
+        update_tag(ec2, instance_id, "ACTIVE")
+        return
+
+    print(f"[{instance_id}] step 1 insufficient — step 2: full reinstall")
+    inv = run_ssm_command(
+        ssm, instance_id, FIX_STEP2_COMMANDS,
+        poll_timeout=SSM_INSTALL_TIMEOUT,
+        execution_timeout=SSM_INSTALL_TIMEOUT,
+    )
+    if inv is None:
+        update_tag(ec2, instance_id, "NOT_FIXED")
+        return
+
+    time.sleep(5)
+    if is_gpumon_running(ssm, instance_id):
+        print(f"[{instance_id}] fixed by step 2")
+        update_tag(ec2, instance_id, "ACTIVE")
+    else:
+        print(f"[{instance_id}] could not be fixed — manual intervention required")
+        update_tag(ec2, instance_id, "NOT_FIXED")
+
+
+def handle_delete(ec2, ssm, instance_id: str) -> None:
+    """Stop the Docker stack, remove systemd timer, crontab entry, and repo."""
+    inv = run_ssm_command(
+        ssm, instance_id, DELETE_COMMANDS,
+        poll_timeout=SSM_FIX_TIMEOUT,
+        execution_timeout=SSM_FIX_TIMEOUT,
+    )
+    if inv is not None:
+        update_tag(ec2, instance_id, "")
+        print(f"[{instance_id}] gpumon removed")
+    else:
+        print(f"[{instance_id}] delete command failed")
+
+
+def handle_migrate(ec2, ssm, instance_id: str, branch: str) -> None:
+    """Migrate a legacy (non-Docker) gpumon instance to the Docker deployment.
+
+    Stops any old systemd units or bare Python processes, wipes the repo,
+    re-clones at branch, and runs autoinstall.sh end-to-end.  Verification
+    uses is_gpumon_dockerized() so a still-running legacy process does not
+    mask a failed Docker install.
+    """
+    if not ensure_iam_role(ec2, instance_id):
+        update_tag(ec2, instance_id, "FAILED")
+        return
+
+    print(f"[{instance_id}] starting migration to Docker deployment (branch '{branch}')")
+    inv = run_ssm_command(
+        ssm, instance_id, migrate_commands(branch),
+        poll_timeout=SSM_MIGRATE_TIMEOUT,
+        execution_timeout=SSM_MIGRATE_TIMEOUT,
+    )
+    if inv is None:
+        print(f"[{instance_id}] migration command could not be sent — SSM agent may be absent")
+        update_tag(ec2, instance_id, "PENDING_SSM")
+        return
+
+    if inv["Status"] != "Success":
+        print(f"[{instance_id}] migration script failed: {inv.get('StandardErrorContent', '')[:300]}")
+        update_tag(ec2, instance_id, "FAILED")
+        return
+
+    time.sleep(5)
+    if is_gpumon_dockerized(ssm, instance_id):
+        print(f"[{instance_id}] migration complete — Docker container running")
+        update_tag(ec2, instance_id, "ACTIVE")
+    else:
+        print(f"[{instance_id}] migration finished but Docker container not detected — marking FAILED")
+        update_tag(ec2, instance_id, "FAILED")
+
+
+# ---------------------------------------------------------------------------
+# Lambda entry point
+# ---------------------------------------------------------------------------
+
+def lambda_handler(event, context):
+    print("lambda_handler: starting fleet sweep")
+
+    for region in REGIONS:
+        ec2, ssm = get_clients(region)
+
+        try:
+            instances = get_all_instances(ec2)
+        except ClientError as e:
+            print(f"[{region}] error listing instances: {e}")
+            continue
+
+        for instance in instances:
+            instance_id = instance["InstanceId"]
+            state       = instance["State"]["Name"]
+            gpumon_tag  = get_gpumon_tag(instance)
+
+            if gpumon_tag is None:
+                continue
+
+            tag_value = gpumon_tag["Value"].strip()
+
+            # GPUMON_BRANCH overrides per instance; fallback differs by action:
+            # INSTALL defaults to main (legacy path), MIGRATE defaults to
+            # the Docker branch so the admin needn't set the tag explicitly.
+            all_tags = {t["Key"]: t["Value"] for t in instance.get("Tags", [])}
+            branch_override = all_tags.get(BRANCH_TAG_KEY)
+
+            print(f"[{region}][{instance_id}] state={state} tag={tag_value!r}")
+
+            try:
+                if tag_value.lower() == "install" or tag_value == "PENDING_SSM":
+                    branch = branch_override or DEFAULT_BRANCH
+                    if state == "running":
+                        handle_install(ec2, ssm, instance_id, branch)
+                    else:
+                        print(f"[{instance_id}] waiting for instance to reach running state")
+
+                elif tag_value == "MIGRATE":
+                    branch = branch_override or DOCKER_BRANCH
+                    if state == "running":
+                        handle_migrate(ec2, ssm, instance_id, branch)
+                    else:
+                        print(f"[{instance_id}] MIGRATE skipped — instance not running")
+
+                elif state != "running" and tag_value not in ("", "INACTIVE"):
+                    update_tag(ec2, instance_id, "INACTIVE")
+
+                elif state == "running" and tag_value == "FAILED":
+                    handle_fix(ec2, ssm, instance_id)
+
+                elif state == "running" and tag_value in ("ACTIVE", "INACTIVE"):
+                    handle_check(ec2, ssm, instance_id)
+
+                elif tag_value == "DELETE":
+                    handle_delete(ec2, ssm, instance_id)
+
+                elif tag_value == "NOT_FIXED":
+                    print(f"[{instance_id}] NOT_FIXED — skipping until manually resolved")
+
+            except ClientError as e:
+                if e.response["Error"]["Code"] == "RequestLimitExceeded":
+                    print(f"[{region}] rate limited — backing off 5 s")
+                    time.sleep(5)
+                else:
+                    print(f"[{region}][{instance_id}] unexpected error: {e}")
+
+    print("lambda_handler: fleet sweep complete")

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -76,6 +76,8 @@ FIX_STEP2_COMMANDS = [
 # Delete: stop stack, remove timer and crontab entry, wipe repo.
 DELETE_COMMANDS = [
     f"cd {GPUMON_DIR} && sudo docker compose down || true",
+    # Fallback: stop/remove any lingering containers by name label regardless of compose state
+    "sudo docker ps -a --filter 'label=com.docker.compose.project=gpumon' -q | xargs -r sudo docker rm -f || true",
     "sudo systemctl disable --now gpumon-update.timer 2>/dev/null || true",
     "sudo rm -f /etc/systemd/system/gpumon-update.service /etc/systemd/system/gpumon-update.timer",
     "sudo systemctl daemon-reload 2>/dev/null || true",

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -67,9 +67,13 @@ FIX_STEP1_COMMANDS = [
     f"fi",
 ]
 
-# Fix step 2 (full reinstall): reset sentinel so autoinstall.sh re-runs everything.
+# Fix step 2 (full reinstall): re-clone the repo (in case it is corrupted) then
+# run autoinstall.sh end-to-end.  Removing SENTINEL alone is not enough if the
+# repo itself is the broken artifact.
 FIX_STEP2_COMMANDS = [
     f"sudo rm -f {SENTINEL}",
+    f"sudo rm -rf {GPUMON_DIR}",
+    f"sudo git clone --branch {DOCKER_BRANCH} {GPUMON_REPO} {GPUMON_DIR}",
     f"sudo bash {GPUMON_DIR}/autoinstall.sh",
 ]
 

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -78,11 +78,12 @@ DELETE_COMMANDS = [
     f"cd {GPUMON_DIR} && sudo docker compose down || true",
     # Fallback: stop/remove any lingering containers by name label regardless of compose state
     "sudo docker ps -a --filter 'label=com.docker.compose.project=gpumon' -q | xargs -r sudo docker rm -f || true",
-    "sudo systemctl disable --now gpumon-update.timer 2>/dev/null || true",
-    "sudo rm -f /etc/systemd/system/gpumon-update.service /etc/systemd/system/gpumon-update.timer",
+    "sudo systemctl disable --now gpumon-update.timer gpumon-boot.service 2>/dev/null || true",
+    "sudo rm -f /etc/systemd/system/gpumon-update.service /etc/systemd/system/gpumon-update.timer "
+    "           /etc/systemd/system/gpumon-boot.service",
     "sudo systemctl daemon-reload 2>/dev/null || true",
     "crontab -l 2>/dev/null | grep -v halt_it.sh | crontab - || true",
-    "sudo rm -f /usr/local/sbin/halt_it.sh /usr/local/sbin/gpumon-update.sh",
+    "sudo rm -f /usr/local/sbin/halt_it.sh /usr/local/sbin/gpumon-update.sh /usr/local/sbin/gpumon-boot.sh",
     f"sudo rm -rf {GPUMON_DIR}",
     f"sudo rm -f {SENTINEL}",
 ]

--- a/lambda_manager.py
+++ b/lambda_manager.py
@@ -63,7 +63,7 @@ FIX_STEP1_COMMANDS = [
     f"if nvidia-smi --list-gpus >/dev/null 2>&1 && [ \"$(nvidia-smi --list-gpus | wc -l)\" -gt 0 ]; then "
     f"  sudo docker compose -f {GPUMON_DIR}/docker-compose.yml up -d --build; "
     f"else "
-    f"  sudo docker compose -f {GPUMON_DIR}/docker-compose.yml -f {GPUMON_DIR}/docker-compose.cpu.yml up -d --build; "
+    f"  sudo docker compose -f {GPUMON_DIR}/docker-compose.cpu.yml up -d --build; "
     f"fi",
 ]
 

--- a/mon_utils.py
+++ b/mon_utils.py
@@ -17,7 +17,6 @@ from urllib.request import Request, urlopen
 
 import boto3
 import psutil
-import requests
 
 if TYPE_CHECKING:
     from slack_dm import SlackDMClient
@@ -96,33 +95,6 @@ def create_tag(ec2_client: Any, instance_id: str, tag_name: str, default_value: 
         Tags=[{"Key": tag_name, "Value": default_value}],
     )
     print(f"Tag '{tag_name}' = '{default_value}' added to {instance_id}.")
-
-
-# ── Slack ─────────────────────────────────────────────────────────────────────
-
-def resolve_webhooks(team: str) -> tuple[str | None, str | None]:
-    """Return (team_webhook, debug_webhook). Either may be None if not configured."""
-    debug_webhook = os.getenv("DEBUG_WEBHOOK_URL")
-    team_env_key = f"{team}_TEAM_WEBHOOK_URL"
-    team_webhook = os.getenv(team_env_key)
-    if team_webhook is None:
-        print(f"WARNING: env var {team_env_key} not set; falling back to DEBUG_WEBHOOK_URL")
-        team_webhook = debug_webhook
-    if team_webhook is None:
-        print("WARNING: neither team webhook nor DEBUG_WEBHOOK_URL is configured — Slack alerts disabled")
-    return team_webhook, debug_webhook
-
-
-def send_slack(webhook_url: str | None, message: str) -> None:
-    if not webhook_url:
-        print(f"send_slack: no webhook URL, dropping message: {message[:80]}")
-        return
-    try:
-        resp = requests.post(webhook_url, json={"text": message}, timeout=10)
-        if resp.status_code != 200:
-            print(f"Slack returned {resp.status_code}: {resp.text[:120]}")
-    except Exception as exc:
-        print(f"send_slack error: {exc}")
 
 
 # ── Network ───────────────────────────────────────────────────────────────────

--- a/mon_utils.py
+++ b/mon_utils.py
@@ -70,7 +70,7 @@ POLICIES: dict[str, dict[str, int]] = {
     "SEVERE":   {"restart_backoff": 0,      "cpu_threshold": 20, "gpu_threshold": 2,  "network_threshold": 15000},
     "SPOT":     {"restart_backoff": 0,      "cpu_threshold": 20, "gpu_threshold": 10, "network_threshold": 30000},
     "SUSPEND":  {"restart_backoff": 864000, "cpu_threshold": 10, "gpu_threshold": 10, "network_threshold": 15000},
-    "STANDARD": {"restart_backoff": 3600,   "cpu_threshold": 10, "gpu_threshold": 10, "network_threshold": 15000},
+    "STANDARD": {"restart_backoff": 0,       "cpu_threshold": 10, "gpu_threshold": 10, "network_threshold": 15000},
 }
 
 

--- a/mon_utils.py
+++ b/mon_utils.py
@@ -1,0 +1,294 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0
+# Shared utilities for gpumon.py, cpumon.py, and hostmon.py — (c) Paul Seifer, Autobrains LTD
+
+from __future__ import annotations
+
+import fcntl
+import glob
+import json
+import logging
+import os
+import subprocess
+import time
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+from urllib.request import Request, urlopen
+
+import boto3
+import psutil
+import requests
+
+if TYPE_CHECKING:
+    from slack_dm import SlackDMClient
+
+log = logging.getLogger(__name__)
+
+# ── IMDS ──────────────────────────────────────────────────────────────────────
+
+_IMDS_BASE = "http://169.254.169.254/latest/meta-data/"
+_IMDS_TOKEN_URL = "http://169.254.169.254/latest/api/token"
+_TOKEN_TTL_SEC = 21600       # 6 h
+_TOKEN_REFRESH_AT = 19800    # refresh at 5.5 h to stay ahead of expiry
+
+_token: str = ""
+_token_fetched_at: float = 0.0
+
+
+def _get_token() -> str:
+    global _token, _token_fetched_at
+    if time.time() - _token_fetched_at > _TOKEN_REFRESH_AT:
+        req = Request(_IMDS_TOKEN_URL, None,
+                      {"X-aws-ec2-metadata-token-ttl-seconds": str(_TOKEN_TTL_SEC)},
+                      method="PUT")
+        _token = urlopen(req, timeout=5).read().decode()
+        _token_fetched_at = time.time()
+    return _token
+
+
+def _imds(path: str) -> str:
+    req = Request(_IMDS_BASE + path, None,
+                  {"X-aws-ec2-metadata-token": _get_token()}, method="GET")
+    return urlopen(req, timeout=5).read().decode()
+
+
+def fetch_instance_metadata() -> dict[str, str]:
+    az = _imds("placement/availability-zone")
+    return {
+        "instance_id":   _imds("instance-id"),
+        "image_id":      _imds("ami-id"),
+        "instance_type": _imds("instance-type"),
+        "az":            az,
+        "region":        az[:-1],
+        "hostname":      _imds("hostname"),
+    }
+
+
+# ── Policy ────────────────────────────────────────────────────────────────────
+
+POLICIES: dict[str, dict[str, int]] = {
+    "RELAXED":  {"restart_backoff": 7200,   "cpu_threshold": 5,  "gpu_threshold": 10, "network_threshold": 10000},
+    "SEVERE":   {"restart_backoff": 0,      "cpu_threshold": 20, "gpu_threshold": 2,  "network_threshold": 15000},
+    "SPOT":     {"restart_backoff": 0,      "cpu_threshold": 20, "gpu_threshold": 10, "network_threshold": 30000},
+    "SUSPEND":  {"restart_backoff": 864000, "cpu_threshold": 10, "gpu_threshold": 10, "network_threshold": 15000},
+    "STANDARD": {"restart_backoff": 3600,   "cpu_threshold": 10, "gpu_threshold": 10, "network_threshold": 15000},
+}
+
+
+def get_policy_config(policy: str) -> dict[str, int]:
+    cfg = POLICIES.get(policy, POLICIES["STANDARD"])
+    print(f"POLICY TAG detected: {policy} → {cfg}")
+    return cfg
+
+
+# ── Tags ──────────────────────────────────────────────────────────────────────
+
+def get_instance_tags(ec2_client: Any, instance_id: str) -> dict[str, str]:
+    response = ec2_client.describe_tags(
+        Filters=[{"Name": "resource-id", "Values": [instance_id]}]
+    )
+    return {t["Key"]: t["Value"] for t in response["Tags"]}
+
+
+def create_tag(ec2_client: Any, instance_id: str, tag_name: str, default_value: str) -> None:
+    ec2_client.create_tags(
+        Resources=[instance_id],
+        Tags=[{"Key": tag_name, "Value": default_value}],
+    )
+    print(f"Tag '{tag_name}' = '{default_value}' added to {instance_id}.")
+
+
+# ── Slack ─────────────────────────────────────────────────────────────────────
+
+def resolve_webhooks(team: str) -> tuple[str | None, str | None]:
+    """Return (team_webhook, debug_webhook). Either may be None if not configured."""
+    debug_webhook = os.getenv("DEBUG_WEBHOOK_URL")
+    team_env_key = f"{team}_TEAM_WEBHOOK_URL"
+    team_webhook = os.getenv(team_env_key)
+    if team_webhook is None:
+        print(f"WARNING: env var {team_env_key} not set; falling back to DEBUG_WEBHOOK_URL")
+        team_webhook = debug_webhook
+    if team_webhook is None:
+        print("WARNING: neither team webhook nor DEBUG_WEBHOOK_URL is configured — Slack alerts disabled")
+    return team_webhook, debug_webhook
+
+
+def send_slack(webhook_url: str | None, message: str) -> None:
+    if not webhook_url:
+        print(f"send_slack: no webhook URL, dropping message: {message[:80]}")
+        return
+    try:
+        resp = requests.post(webhook_url, json={"text": message}, timeout=10)
+        if resp.status_code != 200:
+            print(f"Slack returned {resp.status_code}: {resp.text[:120]}")
+    except Exception as exc:
+        print(f"send_slack error: {exc}")
+
+
+# ── Network ───────────────────────────────────────────────────────────────────
+
+def get_network_stats(cw_client: Any, instance_id: str, prev_network: float) -> float:
+    """Return combined NetworkPacketsIn + NetworkPacketsOut over the last 5 min."""
+    end = datetime.utcnow()
+    start = end - timedelta(minutes=5)
+    fmt = "%Y-%m-%dT%H:%M:%SZ"
+
+    def _query(metric_name: str) -> float | None:
+        data = cw_client.get_metric_statistics(
+            Period=60,
+            StartTime=start.strftime(fmt),
+            EndTime=end.strftime(fmt),
+            MetricName=metric_name,
+            Namespace="AWS/EC2",
+            Statistics=["Maximum"],
+            Unit="Count",
+            Dimensions=[{"Name": "InstanceId", "Value": instance_id}],
+        )
+        pts = data.get("Datapoints", [])
+        return pts[0]["Maximum"] if pts else None
+
+    packets_in = _query("NetworkPacketsIn")
+    packets_out = _query("NetworkPacketsOut")
+
+    # Fallback: use half the previous total to avoid false idle on missing data.
+    # On the very first call prev_network=99, so the fallback is 49 — safely non-zero.
+    fallback = max(prev_network / 2, 1.0)
+    if packets_in is None:
+        print("NetworkPacketsIn: no datapoints, using fallback")
+        packets_in = fallback
+    if packets_out is None:
+        print("NetworkPacketsOut: no datapoints, using fallback")
+        packets_out = fallback
+
+    return round(packets_in) + round(packets_out)
+
+
+# ── CPU ───────────────────────────────────────────────────────────────────────
+
+def seconds_elapsed() -> float:
+    return time.time() - psutil.boot_time()
+
+
+def get_per_core_cpu_utilization() -> list[float]:
+    return psutil.cpu_percent(interval=1, percpu=True)
+
+
+def calculate_average_core_utilization(cache: list[list[float]]) -> list[float]:
+    return [sum(d) / len(d) if d else 0.0 for d in cache]
+
+
+# ── Crontab ───────────────────────────────────────────────────────────────────
+
+_CRON_LOCK = "/tmp/gpumon_crontab.lock"
+
+
+def ensure_halt_it_crontab(cron_job: str) -> None:
+    """Add halt_it.sh cron entry exactly once, even if gpumon and cpumon start simultaneously."""
+    try:
+        with open(_CRON_LOCK, "w") as lock_fh:
+            fcntl.flock(lock_fh, fcntl.LOCK_EX)
+            result = subprocess.run(
+                ["crontab", "-l"], capture_output=True, text=True
+            )
+            existing = result.stdout if result.returncode == 0 else ""
+            if "halt_it.sh" in existing:
+                print("halt_it.sh already in crontab, skipping")
+                return
+            new_crontab = existing.rstrip("\n") + "\n" + cron_job + "\n"
+            proc = subprocess.Popen(["crontab", "-"], stdin=subprocess.PIPE, text=True)
+            proc.communicate(input=new_crontab)
+            if proc.returncode == 0:
+                print("halt_it.sh cron job added")
+            else:
+                print("Failed to update crontab")
+    except Exception as exc:
+        print(f"ensure_halt_it_crontab error: {exc}")
+
+
+# ── Log cleanup ───────────────────────────────────────────────────────────────
+
+def cleanup_old_logs(prefix: str, max_age_hours: int = 48) -> None:
+    """Delete log files matching prefix that are older than max_age_hours."""
+    cutoff = time.time() - max_age_hours * 3600
+    for path in glob.glob(f"{prefix}*"):
+        try:
+            if os.path.getmtime(path) < cutoff:
+                os.remove(path)
+                print(f"Removed old log: {path}")
+        except OSError:
+            pass
+
+
+# ── Alert rate limiting ───────────────────────────────────────────────────────
+# State is persisted to /tmp so it survives container restarts (the /tmp:/tmp
+# bind-mount keeps the file on the host between container rebuilds).
+
+_ALERT_STATE_FILE = "/tmp/gpumon_alert_state.json"
+
+
+def _load_alert_state() -> dict:
+    try:
+        with open(_ALERT_STATE_FILE) as fh:
+            return json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def _save_alert_state(state: dict) -> None:
+    # Atomic write via temp-file + os.replace() so concurrent processes
+    # (gpumon + cpumon) never see a partial write.
+    tmp = _ALERT_STATE_FILE + ".tmp"
+    try:
+        with open(tmp, "w") as fh:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            json.dump(state, fh)
+        os.replace(tmp, _ALERT_STATE_FILE)
+    except OSError as exc:
+        print(f"alert state save error: {exc}")
+
+
+def should_send_alert(key: str, cooldown_hours: float) -> bool:
+    """Return True if enough time has passed since the last alert of this type."""
+    last_sent = _load_alert_state().get(key)
+    if last_sent is None:
+        return True
+    return time.time() - float(last_sent) > cooldown_hours * 3600
+
+
+def record_alert_sent(key: str) -> None:
+    """Record that an alert of the given type was just sent."""
+    state = _load_alert_state()
+    state[key] = time.time()
+    _save_alert_state(state)
+
+
+# ── Slack DM client factory ───────────────────────────────────────────────────
+
+def fetch_slack_bot_token(secret_id: str, secret_region: str) -> str | None:
+    """Fetch the Slack Bot OAuth token from Secrets Manager. Returns None on failure."""
+    try:
+        sm = boto3.client("secretsmanager", region_name=secret_region)
+        resp = sm.get_secret_value(SecretId=secret_id)
+        token = (resp.get("SecretString") or "").strip()
+        if not token:
+            print(f"fetch_slack_bot_token: secret '{secret_id}' is empty")
+            return None
+        if not token.startswith("xoxb-"):
+            print(f"fetch_slack_bot_token: value does not look like a Bot token (xoxb-...)")
+        return token
+    except Exception as exc:
+        print(f"fetch_slack_bot_token: could not fetch '{secret_id}' from {secret_region}: {exc}")
+        return None
+
+
+def build_slack_dm_client(secret_id: str, secret_region: str) -> SlackDMClient | None:
+    """Fetch bot token and build a SlackDMClient. Returns None if unavailable."""
+    token = fetch_slack_bot_token(secret_id, secret_region)
+    if not token:
+        return None
+    try:
+        from slack_dm import SlackDMClient  # local import to avoid circular dep
+        return SlackDMClient(token)
+    except Exception as exc:
+        print(f"build_slack_dm_client: failed to initialise: {exc}")
+        return None

--- a/mon_utils.py
+++ b/mon_utils.py
@@ -123,16 +123,14 @@ def get_network_stats(cw_client: Any, instance_id: str, prev_network: float) -> 
     packets_in = _query("NetworkPacketsIn")
     packets_out = _query("NetworkPacketsOut")
 
-    # When CW data is missing treat the network as active (not idle).
-    # Halving toward zero on repeated misses would eventually trigger a false shutdown.
-    # A large sentinel value safely clears every policy threshold.
-    _MISSING = 1_000_000.0
-    if packets_in is None:
-        print("NetworkPacketsIn: no datapoints — treating as active to prevent false idle")
-        packets_in = _MISSING
-    if packets_out is None:
-        print("NetworkPacketsOut: no datapoints — treating as active to prevent false idle")
-        packets_out = _MISSING
+    if packets_in is None or packets_out is None:
+        # CW basic monitoring has a ~1-2 min publication lag; brief gaps are normal.
+        # Return the previous value so a short CW gap doesn't invalidate the halt window.
+        # A sustained 15-min CW outage (needed to trigger a false idle) is far less
+        # likely than the old 2M sentinel repeatedly blocking legitimate shutdowns.
+        print(f"NetworkPacketsIn={packets_in} NetworkPacketsOut={packets_out}: "
+              f"CW datapoint missing — reusing prev_network={prev_network}")
+        return prev_network
 
     return round(packets_in) + round(packets_out)
 

--- a/mon_utils.py
+++ b/mon_utils.py
@@ -220,46 +220,44 @@ def cleanup_old_logs(prefix: str, max_age_hours: int = 48) -> None:
 
 
 # ── Alert rate limiting ───────────────────────────────────────────────────────
-# State is persisted to /tmp so it survives container restarts (the /tmp:/tmp
-# bind-mount keeps the file on the host between container rebuilds).
+# State persisted to /tmp so it survives container restarts via /tmp:/tmp mount.
+# The lock file serialises concurrent access between gpumon and cpumon so the
+# check and record happen atomically — preventing duplicate DMs.
 
 _ALERT_STATE_FILE = "/tmp/gpumon_alert_state.json"
+_ALERT_LOCK_FILE  = "/tmp/gpumon_alert_state.lock"
 
 
-def _load_alert_state() -> dict:
+def try_record_alert(key: str, cooldown_hours: float) -> bool:
+    """Atomically check cooldown and record the alert if it should be sent.
+
+    Returns True if the alert should be sent (cooldown elapsed or first time).
+    Holds an exclusive lock for the entire read-check-write sequence so
+    concurrent gpumon and cpumon processes cannot both pass the cooldown check.
+    """
     try:
-        with open(_ALERT_STATE_FILE) as fh:
-            return json.load(fh)
-    except (FileNotFoundError, json.JSONDecodeError):
-        return {}
-
-
-def _save_alert_state(state: dict) -> None:
-    # Atomic write via temp-file + os.replace() so concurrent processes
-    # (gpumon + cpumon) never see a partial write.
-    tmp = _ALERT_STATE_FILE + ".tmp"
-    try:
-        with open(tmp, "w") as fh:
-            fcntl.flock(fh, fcntl.LOCK_EX)
-            json.dump(state, fh)
-        os.replace(tmp, _ALERT_STATE_FILE)
+        with open(_ALERT_LOCK_FILE, "w") as lock_fh:
+            fcntl.flock(lock_fh, fcntl.LOCK_EX)
+            # Read current state under lock
+            try:
+                with open(_ALERT_STATE_FILE) as fh:
+                    state = json.load(fh)
+            except (FileNotFoundError, json.JSONDecodeError):
+                state = {}
+            # Check cooldown
+            last_sent = state.get(key)
+            if last_sent is not None and time.time() - float(last_sent) <= cooldown_hours * 3600:
+                return False
+            # Record and write atomically
+            state[key] = time.time()
+            tmp = _ALERT_STATE_FILE + ".tmp"
+            with open(tmp, "w") as fh:
+                json.dump(state, fh)
+            os.replace(tmp, _ALERT_STATE_FILE)
+            return True
     except OSError as exc:
-        print(f"alert state save error: {exc}")
-
-
-def should_send_alert(key: str, cooldown_hours: float) -> bool:
-    """Return True if enough time has passed since the last alert of this type."""
-    last_sent = _load_alert_state().get(key)
-    if last_sent is None:
-        return True
-    return time.time() - float(last_sent) > cooldown_hours * 3600
-
-
-def record_alert_sent(key: str) -> None:
-    """Record that an alert of the given type was just sent."""
-    state = _load_alert_state()
-    state[key] = time.time()
-    _save_alert_state(state)
+        print(f"try_record_alert error: {exc}")
+        return False
 
 
 # ── Slack DM client factory ───────────────────────────────────────────────────

--- a/mon_utils.py
+++ b/mon_utils.py
@@ -65,12 +65,12 @@ def fetch_instance_metadata() -> dict[str, str]:
 
 # ── Policy ────────────────────────────────────────────────────────────────────
 
-POLICIES: dict[str, dict[str, int]] = {
-    "RELAXED":  {"restart_backoff": 7200,   "cpu_threshold": 5,  "gpu_threshold": 10, "network_threshold": 10000},
-    "SEVERE":   {"restart_backoff": 0,      "cpu_threshold": 20, "gpu_threshold": 2,  "network_threshold": 15000},
-    "SPOT":     {"restart_backoff": 0,      "cpu_threshold": 20, "gpu_threshold": 10, "network_threshold": 30000},
-    "SUSPEND":  {"restart_backoff": 864000, "cpu_threshold": 10, "gpu_threshold": 10, "network_threshold": 15000},
-    "STANDARD": {"restart_backoff": 0,       "cpu_threshold": 10, "gpu_threshold": 10, "network_threshold": 15000},
+POLICIES: dict[str, dict[str, Any]] = {
+    "RELAXED":  {"restart_backoff": 7200,   "cpu_threshold": 5,  "gpu_threshold": 10, "network_threshold": 10000, "shutdown_eta": "~2 hours"},
+    "SEVERE":   {"restart_backoff": 0,      "cpu_threshold": 20, "gpu_threshold": 2,  "network_threshold": 15000, "shutdown_eta": "~15 minutes"},
+    "SPOT":     {"restart_backoff": 0,      "cpu_threshold": 20, "gpu_threshold": 10, "network_threshold": 30000, "shutdown_eta": "~15 minutes"},
+    "SUSPEND":  {"restart_backoff": 864000, "cpu_threshold": 10, "gpu_threshold": 10, "network_threshold": 15000, "shutdown_eta": "~2 hours"},
+    "STANDARD": {"restart_backoff": 0,      "cpu_threshold": 10, "gpu_threshold": 10, "network_threshold": 15000, "shutdown_eta": "~1 hour"},
 }
 
 

--- a/mon_utils.py
+++ b/mon_utils.py
@@ -144,21 +144,23 @@ def get_network_stats(cw_client: Any, instance_id: str, prev_network: float) -> 
             Unit="Count",
             Dimensions=[{"Name": "InstanceId", "Value": instance_id}],
         )
-        pts = data.get("Datapoints", [])
+        # GetMetricStatistics does not guarantee chronological order — sort first.
+        pts = sorted(data.get("Datapoints", []), key=lambda p: p["Timestamp"], reverse=True)
         return pts[0]["Maximum"] if pts else None
 
     packets_in = _query("NetworkPacketsIn")
     packets_out = _query("NetworkPacketsOut")
 
-    # Fallback: use half the previous total to avoid false idle on missing data.
-    # On the very first call prev_network=99, so the fallback is 49 — safely non-zero.
-    fallback = max(prev_network / 2, 1.0)
+    # When CW data is missing treat the network as active (not idle).
+    # Halving toward zero on repeated misses would eventually trigger a false shutdown.
+    # A large sentinel value safely clears every policy threshold.
+    _MISSING = 1_000_000.0
     if packets_in is None:
-        print("NetworkPacketsIn: no datapoints, using fallback")
-        packets_in = fallback
+        print("NetworkPacketsIn: no datapoints — treating as active to prevent false idle")
+        packets_in = _MISSING
     if packets_out is None:
-        print("NetworkPacketsOut: no datapoints, using fallback")
-        packets_out = fallback
+        print("NetworkPacketsOut: no datapoints — treating as active to prevent false idle")
+        packets_out = _MISSING
 
     return round(packets_in) + round(packets_out)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+boto3>=1.34.0
+psutil>=5.9.0
+requests>=2.31.0
+nvidia-ml-py>=12.535.0
+slack-sdk>=3.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 boto3>=1.34.0
 psutil>=5.9.0
-requests>=2.31.0
 nvidia-ml-py>=12.535.0
 slack-sdk>=3.27.0

--- a/slack_dm.py
+++ b/slack_dm.py
@@ -12,6 +12,9 @@ except ImportError:
     _SDK_AVAILABLE = False
 
 
+FALLBACK_EMPLOYEE = "Paul Seifer"
+
+
 class SlackDMClient:
     """Send Slack DMs to employees by name or email via a Bot OAuth token.
 
@@ -106,16 +109,25 @@ class SlackDMClient:
     # ── Public API ────────────────────────────────────────────────────────────
 
     def send_dm(self, employee: str, message: str) -> bool:
-        """Send a DM to employee. Returns True on success."""
+        """Send a DM to employee. Returns True on success.
+
+        If employee cannot be resolved to a Slack user, falls back to
+        FALLBACK_EMPLOYEE so the alert is not silently dropped.
+        """
         try:
+            recipient = employee
             user_id = self.find_user_id(employee)
+            if not user_id and employee != FALLBACK_EMPLOYEE:
+                print(f"slack_dm: '{employee}' unresolvable — falling back to '{FALLBACK_EMPLOYEE}'")
+                recipient = FALLBACK_EMPLOYEE
+                user_id = self.find_user_id(FALLBACK_EMPLOYEE)
             if not user_id:
                 return False
             channel_id = self._open_dm_channel(user_id)
             if not channel_id:
                 return False
             self._client.chat_postMessage(channel=channel_id, text=message)
-            print(f"slack_dm: DM sent to '{employee}'")
+            print(f"slack_dm: DM sent to '{recipient}'")
             return True
         except SlackApiError as exc:
             print(f"slack_dm: send_dm('{employee}') failed: {exc.response['error']}")

--- a/slack_dm.py
+++ b/slack_dm.py
@@ -1,0 +1,122 @@
+# Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0
+# Slack Bot DM client — (c) Paul Seifer, Autobrains LTD
+
+from __future__ import annotations
+
+try:
+    from slack_sdk import WebClient
+    from slack_sdk.errors import SlackApiError
+    _SDK_AVAILABLE = True
+except ImportError:
+    _SDK_AVAILABLE = False
+
+
+class SlackDMClient:
+    """Send Slack DMs to employees by name or email via a Bot OAuth token.
+
+    Employee lookup order:
+      1. If value contains '@' → users.lookupByEmail (exact, fast)
+      2. Otherwise → match against real_name / display_name from users.list
+         (fetched once at first use, then cached for the process lifetime)
+    """
+
+    def __init__(self, bot_token: str) -> None:
+        if not _SDK_AVAILABLE:
+            raise ImportError("slack-sdk package is not installed")
+        self._client = WebClient(token=bot_token)
+        self._user_id_cache: dict[str, str] = {}    # employee string → user_id
+        self._channel_cache: dict[str, str] = {}    # user_id → DM channel_id
+        self._users_by_name: dict[str, str] = {}    # lowercase name → user_id
+        self._users_by_email: dict[str, str] = {}   # lowercase email → user_id
+        self._users_list_loaded = False
+
+    # ── User resolution ───────────────────────────────────────────────────────
+
+    def _load_users_list(self) -> None:
+        if self._users_list_loaded:
+            return
+        cursor = None
+        try:
+            while True:
+                kwargs: dict = {"limit": 200}
+                if cursor:
+                    kwargs["cursor"] = cursor
+                result = self._client.users_list(**kwargs)
+                for member in result.get("members", []):
+                    if member.get("deleted") or member.get("is_bot"):
+                        continue
+                    uid = member["id"]
+                    profile = member.get("profile", {})
+                    for field in ("real_name", "display_name"):
+                        name = (profile.get(field) or "").strip().lower()
+                        if name:
+                            self._users_by_name[name] = uid
+                    email = (profile.get("email") or "").strip().lower()
+                    if email:
+                        self._users_by_email[email] = uid
+                cursor = (result.get("response_metadata") or {}).get("next_cursor")
+                if not cursor:
+                    break
+            self._users_list_loaded = True
+            print(f"slack_dm: loaded {len(self._users_by_name)} users from workspace")
+        except SlackApiError as exc:
+            print(f"slack_dm: failed to load users list: {exc}")
+
+    def find_user_id(self, employee: str) -> str | None:
+        if employee in self._user_id_cache:
+            return self._user_id_cache[employee]
+
+        uid: str | None = None
+
+        if "@" in employee:
+            try:
+                result = self._client.users_lookupByEmail(email=employee)
+                uid = result["user"]["id"]
+            except SlackApiError as exc:
+                print(f"slack_dm: lookupByEmail('{employee}') failed: {exc.response['error']}")
+
+        if uid is None:
+            self._load_users_list()
+            key = employee.strip().lower()
+            uid = self._users_by_name.get(key) or self._users_by_email.get(key)
+
+        if uid:
+            self._user_id_cache[employee] = uid
+            print(f"slack_dm: resolved '{employee}' → {uid}")
+        else:
+            print(f"slack_dm: could not resolve '{employee}' to a Slack user")
+
+        return uid
+
+    # ── DM channel ────────────────────────────────────────────────────────────
+
+    def _open_dm_channel(self, user_id: str) -> str | None:
+        if user_id in self._channel_cache:
+            return self._channel_cache[user_id]
+        try:
+            result = self._client.conversations_open(users=[user_id])
+            channel_id: str = result["channel"]["id"]
+            self._channel_cache[user_id] = channel_id
+            return channel_id
+        except SlackApiError as exc:
+            print(f"slack_dm: conversations_open({user_id}) failed: {exc.response['error']}")
+            return None
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def send_dm(self, employee: str, message: str) -> bool:
+        """Send a DM to employee. Returns True on success."""
+        try:
+            user_id = self.find_user_id(employee)
+            if not user_id:
+                return False
+            channel_id = self._open_dm_channel(user_id)
+            if not channel_id:
+                return False
+            self._client.chat_postMessage(channel=channel_id, text=message)
+            print(f"slack_dm: DM sent to '{employee}'")
+            return True
+        except SlackApiError as exc:
+            print(f"slack_dm: send_dm('{employee}') failed: {exc.response['error']}")
+            return False


### PR DESCRIPTION
## Summary

- **Containerised deployment**: gpumon and cpumon now run inside a Docker container (`docker compose`). `autoinstall.sh` handles Docker + NVIDIA Container Toolkit install, builds the image, starts the stack, and registers the systemd auto-update timer and host crontab for `halt_it.sh`.
- **Lambda fleet manager** (`lambda_manager.py`): tag-driven install, health-check, progressive fix (fast git-reset → full reinstall), migration from legacy bare-Python installs, and delete — all via SSM with no SSH.
- **Host metrics** (`hostmon.py`, `mon_utils.py`): root-disk free, RAM usage, top process — published to CloudWatch `Host-metrics` namespace.
- **Slack DMs** (`slack_dm.py`): idle, low-disk, and high-memory alerts routed to the responsible employee via Slack Bot API, with per-alert cooldowns.
- **halt_it.sh rewrite**: replaced fragile line-count STEP logic with a real timestamp-based idle window; raised sample-coverage threshold to 90%; SPOT/SEVERE policy uses 15-min window instead of 2 h.

## What was tested (live on `i-0bb086491137978bd`, eu-west-1)

- [x] **Install**: `GPUMON=install` → Lambda SSM run → container up → tag `ACTIVE`
- [x] **Health-check**: `ACTIVE` instance re-swept → stays `ACTIVE`
- [x] **Fix (container stopped)**: stop container → first sweep tags `FAILED` → second sweep rebuilds image → `ACTIVE`
- [x] **Delete**: `GPUMON=DELETE` → Lambda tears down container, timer, crontab, repo → tag cleared
- [x] **SPOT policy**: `GPUMON_POLICY=SPOT` → `halt_it.sh` reports `Policy: SPOT  Window: 900s`
- [x] **kill_halt.sh**: writes `/tmp/timestamp.txt` backoff, kills any running `halt_it.sh` process

## Key fixes made during staging

| Commit | Fix |
|--------|-----|
| `cbb879f` | halt_it.sh: real timestamp window instead of line-count STEP |
| `cae997b` | halt_it.sh: 90% sample-coverage threshold (was 50%) |
| `4551f58` | All apt-get calls: `DPkg::Lock::Timeout=120` |
| `67bda48` | `git fetch + reset --hard @{upstream}` instead of `git pull --force` |
| `f68c110` | `gpg --batch --no-tty` for SSM (no TTY); NVIDIA toolkit idempotency guard |
| `bc9ebe0` | Stop `unattended-upgrades` + fuser wait before any apt-get (lock race fix) |
| `b2b22e3` | DELETE: label-based fallback `docker rm -f` for orphan containers |

## Test plan

- [ ] Deploy Lambda (`lambda_manager.py`) to production fleet function
- [ ] Verify existing ACTIVE instances pass health-check on next sweep without reinstall
- [ ] Tag one non-critical instance `GPUMON=install` on the Docker branch and confirm `ACTIVE`
- [ ] Update `DOCKER_BRANCH = "main"` in `lambda_manager.py` after merge